### PR TITLE
Fix CRUD Realisasi oleh Admin, Fix Singkron List Barang dan Cek Stok + Konfigurasi

### DIFF
--- a/app/Http/Controllers/API/v1/LogisticRealizationItemController.php
+++ b/app/Http/Controllers/API/v1/LogisticRealizationItemController.php
@@ -225,7 +225,7 @@ class LogisticRealizationItemController extends Controller
                 'unit_id' => $request->input('unit_id'),
                 'realization_date' => $request->input('realization_date'),
                 'status' => $request->input('status'),
-                'updated_by' => JWTAuth::user()->roles
+                'updated_by' => JWTAuth::user()->id
             ]
         );
         $model->save();

--- a/app/Http/Controllers/API/v1/LogisticRealizationItemController.php
+++ b/app/Http/Controllers/API/v1/LogisticRealizationItemController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\API\v1;
 
-use App\Needs;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\LogisticRealizationItems;
@@ -48,13 +47,11 @@ class LogisticRealizationItemController extends Controller
     public function add(Request $request)
     {
         $validator = Validator::make($request->all(), [             
-            'agency_id' => 'numeric',
-            'applicant_id' => 'numeric',
-            'product_id' => 'numeric',
-            'quantity' => 'numeric',
+            'agency_id' => 'numeric', 
+            'product_id' => 'numeric', 
             'unit_id' => 'numeric',
             'usage' => 'string',
-            'priority' => 'string', 
+            'priority' => 'string',
             'realization_quantity' => 'numeric',
             'realization_date' => 'date',
             'status' => 'string'
@@ -62,20 +59,14 @@ class LogisticRealizationItemController extends Controller
 
         if ($validator->fails()) {
             return response()->format(422, $validator->errors());
-        } elseif (!in_array($request->priority, Needs::STATUS)) {
-            return response()->json(['status' => 'fail', 'message' => 'priority value is not accepted']);
         } elseif (!in_array($request->status, LogisticRealizationItems::STATUS)) {
             return response()->json(['status' => 'fail', 'message' => 'verification_status_value_is_not_accepted']);
         } else {
             DB::beginTransaction();
-            try {  
-                $need = $this->needStore($request);
-                $request->request->add(['need_id' => $need->id]);
-
+            try {    
                 $realization = $this->realizationStore($request);
 
                 $response = array(
-                    'need' => $need,
                     'realization' => $realization
                 );
                 DB::commit();
@@ -106,28 +97,7 @@ class LogisticRealizationItemController extends Controller
             return response()->json(['errors' => $validator->errors()], 422);
         } else {
             $limit = $request->filled('limit') ? $request->input('limit') : 10;
-            $data = Needs::select(
-                'needs.id',
-                'needs.agency_id',
-                'needs.applicant_id',
-                'needs.product_id',
-                'needs.item',
-                'needs.brand',
-                'needs.quantity',
-                'needs.unit',
-                'needs.usage',
-                'needs.priority',
-                'needs.created_at',
-                'needs.updated_at',
-                'logistic_realization_items.need_id',
-                'logistic_realization_items.realization_quantity',
-                'logistic_realization_items.unit_id',
-                'logistic_realization_items.realization_date',
-                'logistic_realization_items.status',
-                'logistic_realization_items.realization_quantity',
-                'logistic_realization_items.created_by',
-                'logistic_realization_items.updated_by'
-            )
+            $data = LogisticRealizationItems::where('created_by', '999999')
             ->with([
                 'product' => function ($query) {
                     return $query->select(['id', 'name']);
@@ -135,18 +105,11 @@ class LogisticRealizationItemController extends Controller
                 'unit' => function ($query) {
                     return $query->select(['id', 'unit']);
                 }
-            ])
-            ->join('logistic_realization_items', 'logistic_realization_items.need_id', '=', 'needs.id', 'left')
+            ]) 
             ->whereNull('logistic_realization_items.deleted_at')
-            ->where('needs.created_by', 'admin')
-            ->orderBy('needs.id')
-            ->where('needs.agency_id', $request->agency_id)->paginate($limit);
-            $logisticItemSummary = Needs::where('needs.agency_id', $request->agency_id)->sum('quantity');
-            $data->getCollection()->transform(function ($item, $key) use ($logisticItemSummary) {
-                $item->status = !$item->status ? 'not_approved' : $item->status;
-                $item->logistic_item_summary = (int)$logisticItemSummary;
-                return $item;
-            });
+            ->orderBy('id')
+            ->where('agency_id', $request->agency_id)
+            ->paginate($limit);
         }
 
         return response()->format(200, 'success', $data);
@@ -161,11 +124,8 @@ class LogisticRealizationItemController extends Controller
     {
         $validator = Validator::make($request->all(), [    
             'agency_id' => 'numeric',  
-            'product_id' => 'numeric',
-            'quantity' => 'numeric',
-            'unit_id' => 'numeric',
-            'usage' => 'string',
-            'priority' => 'string',
+            'product_id' => 'numeric', 
+            'unit_id' => 'numeric', 
             'realization_quantity' => 'numeric',
             'realization_date' => 'date',
             'status' => 'string', 
@@ -174,19 +134,15 @@ class LogisticRealizationItemController extends Controller
         ]);
 
         if ($validator->fails()) {
-            return response()->format(422, $validator->errors());
-        } elseif (!in_array($request->priority, Needs::STATUS)) {
-            return response()->json(['status' => 'fail', 'message' => 'priority value is not accepted']);
+            return response()->format(422, $validator->errors()); 
         } elseif (!in_array($request->status, LogisticRealizationItems::STATUS)) {
             return response()->json(['status' => 'fail', 'message' => 'verification_status_value_is_not_accepted']);
         } else {
             DB::beginTransaction();
-            try {  
-                $need = $this->needUpdate($request, $id);
+            try {   
                 $realization = $this->realizationUpdate($request, $id);
 
-                $response = array(
-                    'need' => $need,
+                $response = array( 
                     'realization' => $realization
                 );
                 DB::commit();
@@ -207,34 +163,14 @@ class LogisticRealizationItemController extends Controller
     public function destroy($id)
     {
         DB::beginTransaction();
-        try {  
-            $deleteNeed = Needs::where('id', $id)->delete();
-            $deleteRealization = LogisticRealizationItems::where('need_id', $id)->delete();
+        try {   
+            $deleteRealization = LogisticRealizationItems::where('id', $id)->delete();
             DB::commit();
         } catch (\Exception $exception) {
             DB::rollBack();
             return response()->format(400, $exception->getMessage());
         }
         return response()->format(200, 'success', ['id' => $id]);
-    }
-    
-    public function needStore($request)
-    { 
-        $need = Needs::create(
-            [
-                'agency_id' => $request->input('agency_id'),
-                'applicant_id' => $request->input('applicant_id'),
-                'product_id' => $request->input('product_id'),
-                'brand' => $request->input('brand'),
-                'quantity' => $request->input('quantity'),
-                'unit' => $request->input('unit_id'),
-                'usage' => $request->input('usage'),
-                'priority' => $request->input('priority'),
-                'created_by' => 'admin'
-            ]
-        );
-
-        return $need;
     }
 
     public function realizationStore($request)
@@ -248,34 +184,17 @@ class LogisticRealizationItemController extends Controller
                 'unit_id' => $request->input('unit_id'),
                 'realization_date' => $request->input('realization_date'),
                 'status' => $request->input('status'),
+                'created_by' => 999999
             ]
         );
 
         return $realization;
     }
-        
-    public function needUpdate($request, $id)
-    { 
-        $need = Needs::where('id', $id)->update(
-            [
-                'agency_id' => $request->input('agency_id'), 
-                'product_id' => $request->input('product_id'),
-                'brand' => $request->input('brand'),
-                'quantity' => $request->input('quantity'),
-                'unit' => $request->input('unit_id'),
-                'usage' => $request->input('usage'),
-                'priority' => $request->input('priority'),
-                'created_by' => 'admin'
-            ]
-        );
-
-        return $need;
-    }
 
     public function realizationUpdate($request, $id)
     {
         $model = new LogisticRealizationItems();
-        $findOne = LogisticRealizationItems::where('need_id', $id)->orderBy('created_at', 'desc')->first();
+        $findOne = LogisticRealizationItems::find($id);
         $model->fill(
             [ 
                 'need_id' => $id,
@@ -285,6 +204,7 @@ class LogisticRealizationItemController extends Controller
                 'unit_id' => $request->input('unit_id'),
                 'realization_date' => $request->input('realization_date'),
                 'status' => $request->input('status'),
+                'created_by' => 999999
             ]
         );
         $model->save();

--- a/app/Http/Controllers/API/v1/LogisticRequestController.php
+++ b/app/Http/Controllers/API/v1/LogisticRequestController.php
@@ -340,7 +340,7 @@ class LogisticRequestController extends Controller
                 'needs.id',
                 'needs.agency_id',
                 'needs.applicant_id',
-                'needs.product_id',
+                'logistic_realization_items.product_id',
                 'needs.item',
                 'needs.brand',
                 'needs.quantity',
@@ -368,6 +368,7 @@ class LogisticRequestController extends Controller
                 ])
                 ->join('logistic_realization_items', 'logistic_realization_items.need_id', '=', 'needs.id', 'left')
                 ->whereNull('logistic_realization_items.deleted_at')
+                ->orderBy('needs.id')
                 ->where('needs.agency_id', $request->agency_id)->paginate($limit);
             $logisticItemSummary = Needs::where('needs.agency_id', $request->agency_id)->sum('quantity');
             $data->getCollection()->transform(function ($item, $key) use ($logisticItemSummary) {

--- a/app/Http/Controllers/API/v1/ProductsController.php
+++ b/app/Http/Controllers/API/v1/ProductsController.php
@@ -29,6 +29,7 @@ class ProductsController extends Controller
             }
 
             $query->where('products.is_imported', false);
+            $query->where('products.material_group_status', 1);
         } catch (\Exception $exception) {
             return response()->format(400, $exception->getMessage());
         }
@@ -44,7 +45,7 @@ class ProductsController extends Controller
      */
     public function show($id)
     {
-        return Product::findOrFail($id);
+        return Product::where('material_group_status', 1)->where('id', $id)->firstOrFail();
     }
 
     public function productUnit($id)
@@ -56,6 +57,7 @@ class ProductsController extends Controller
                     ->where('master_unit.is_imported', false);
             })
             ->where('products.id', $id)
+            ->where('products.material_group_status', 1)
             ->get();
     }
 
@@ -79,6 +81,7 @@ class ProductsController extends Controller
                 $join->on('product_unit.unit_id', '=', 'master_unit.id');
             })
             ->where('applicants.verification_status', 'verified')
+            ->where('products.material_group_status', 1)
             ->whereBetween('applicants.updated_at', [$startDate, $endDate])
             ->groupBy('products.id');
 

--- a/app/Http/Controllers/API/v1/StockController.php
+++ b/app/Http/Controllers/API/v1/StockController.php
@@ -4,16 +4,21 @@ namespace App\Http\Controllers\API\v1;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Usage;
+use App\Product;
 
 class StockController extends Controller
 {
     public function index(Request $request)
     {
         $param = '';
+        $product = [];
         $api = '';
         
-        if ($request->filled('material_group')) {
-            $param = '{"material_group":"' . $request->input('material_group') . '"}';
+        if ($request->filled('id')) {
+            $product = Product::find($request->input('id'));
+            $materialGroupId = $product->material_group;
+            
+            $param = '{"material_group":"' . $materialGroupId . '"}';
             $api = '/api/soh_fmaterialgroup';
         }
 
@@ -38,8 +43,8 @@ class StockController extends Controller
             }
         }
 
-        $dataFinal = [];
         // Finalisasi data yang akan dilempar
+        $dataFinal = [];
         foreach ($data as $loc => $val) {
             $dataFinal[] = $val;
         }

--- a/app/Imports/LogisticRequestImport.php
+++ b/app/Imports/LogisticRequestImport.php
@@ -247,6 +247,7 @@ class LogisticRequestImport implements ToCollection, WithStartRow
         if (!$product) {
             $product = Product::create([
                 'name' => $productName,
+                'material_group_status' => 1,
                 'is_imported' => true
             ]);
         }

--- a/app/LogisticRealizationItems.php
+++ b/app/LogisticRealizationItems.php
@@ -14,7 +14,8 @@ class LogisticRealizationItems extends Model
         'not_delivered',
         'approved',
         'not_approved',
-        'not_avalivable'
+        'not_avalivable',
+        'replaced'
     ];
 
     protected $table = 'logistic_realization_items';

--- a/app/User.php
+++ b/app/User.php
@@ -11,6 +11,15 @@ class User extends Authenticatable implements JWTSubject {
     use Notifiable;
 
     /**
+     * Constanta for Admin Previledge Roles
+     */
+    const ADMIN_ROLE = [
+        'superadmin',
+        'admin',
+        'dinkesprov',
+    ];
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var array

--- a/database/migrations/2020_07_14_052834_modify_realization_date_column_type_data_at_logistic_realization_items_table.php
+++ b/database/migrations/2020_07_14_052834_modify_realization_date_column_type_data_at_logistic_realization_items_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ModifyRealizationDateColumnTypeDataAtLogisticRealizationItemsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('logistic_realization_items', function (Blueprint $table) {
+            $table->date('realization_date')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('logistic_realization_items', function (Blueprint $table) {
+            $table->dateTime('realization_date')->nullable()->change();
+        });
+    }
+}


### PR DESCRIPTION
CRUD Realisasi oleh Admin:
- Menghilangkan CRUD ke tabel Kebutuhan
- Tidak membutuhkan data-data yang berasal dari tabel kebutuhan
- Pengkondisian baru CRUD untuk dapat dikenal bahwa realisasi tersebut dibuat oleh admin
- Menambah Status Realisasi: Diganti
- Mengubah pengembalian tanggal realisasi hanya dengan tanggal saja
Detail untuk CRUD Realisasi oleh Admin:
https://trello.com/c/o0qI96w6/122-permohonan-admin-dapat-melakukan-tambah-realisasi-distribusi-lainnya-untuk-barang-yang-tidak-ada-pada-permohonan-logistik

Fix List Barang:
- Sekarang Pengkondisian daftar barang yang tampil berdasarkan status material group
Detail untuk List Barang:
https://trello.com/c/D9sIHgW1/112-permohonan-sinkron-data-material-pada-saat-mengajukan-permohonan-dengan-api-terbaru-poslogistik

Fix Cek Stok:
- Sekarang pencarian stok berdasarkan id barang
Detail untuk Fix Cek Stok:
https://trello.com/c/9acT3wy9/113-permohonan-admin-aplikasi-permohonan-dapat-melihat-data-stok-di-aplikasi-permohonan-itu-langsung-di-item-barangnya-tidak-terpisa

Note: membutuhkan eksekusi migrasi untuk dapat berfungsi dengan baik