### PR TITLE
Bug Fix Response of Null Unit ID and Name

### DIFF
--- a/app/Http/Controllers/API/v1/LogisticRequestController.php
+++ b/app/Http/Controllers/API/v1/LogisticRequestController.php
@@ -351,7 +351,7 @@ class LogisticRequestController extends Controller
                 'needs.updated_at',
                 'logistic_realization_items.need_id',
                 'logistic_realization_items.realization_quantity',
-                'logistic_realization_items.unit_id',
+                DB::raw('IFNULL(logistic_realization_items.unit_id, needs.unit) as unit_id'),
                 'logistic_realization_items.realization_date',
                 'logistic_realization_items.status',
                 'logistic_realization_items.realization_quantity',

--- a/app/Http/Controllers/API/v1/ProductsController.php
+++ b/app/Http/Controllers/API/v1/ProductsController.php
@@ -50,7 +50,12 @@ class ProductsController extends Controller
 
     public function productUnit($id)
     {
-        return Product::select('products.id', 'products.name', 'product_unit.unit_id', 'master_unit.unit')
+        $data = Product::select(
+                'products.id', 
+                'products.name',  
+                DB::raw('IFNULL(product_unit.unit_id, 1) as unit_id'),
+                DB::raw('IFNULL(master_unit.unit, "PCS") as unit')
+            )
             ->leftJoin('product_unit', 'product_unit.product_id', '=', 'products.id')
             ->leftJoin('master_unit', function ($join) {
                 $join->on('product_unit.unit_id', '=', 'master_unit.id')
@@ -58,6 +63,8 @@ class ProductsController extends Controller
             })
             ->where('products.id', $id) 
             ->get();
+            
+        return $data;
     }
 
     public function productRequest(Request $request)


### PR DESCRIPTION
Bug fix response ketika Unit ID dan Nama yang didapatkan Null. Ini berpengaruh ketika melakukan Update Realisasi Logistik yang mengakses API Product Unit. Ini terjadi karena di table Product Unit tidak memiliki record dari product yang dicari (LEFT JOIN) sehingga response akan menampilkan null.

Solusi yang diberikan adalah memberi default nilai pada product yang null dengan kondisi yang dilakukan pada saat query-ing.
Default ID 1 dan Default Nama "PCS" adalah yang seharusnya ditampilkan, karena seluruh product yang ada di pikobar mempunyai default id tersebut.

Berikut tampilan Issue yang didapat di PIKOBAR LOGISTIK karena issue null ini.
<img width="277" alt="Unit ID Null" src="https://user-images.githubusercontent.com/19951241/88011247-0f67e000-cb41-11ea-89cc-bfd502863137.png">