### PR TITLE
Add filter empty Letter Number when access API Application letter number list

### DIFF
--- a/app/Http/Controllers/API/v1/RequestLetterController.php
+++ b/app/Http/Controllers/API/v1/RequestLetterController.php
@@ -172,7 +172,11 @@ class RequestLetterController extends Controller
         $data = [];
 
         try { 
-            $list = Applicant::select('id', 'application_letter_number')->where('application_letter_number', 'LIKE', "%{$request->input('application_letter_number')}%")->get();
+            $list = Applicant::select('id', 'application_letter_number')
+                ->where('application_letter_number', 'LIKE', "%{$request->input('application_letter_number')}%")
+                ->where('is_deleted', '!=', 1)
+                ->where('application_letter_number', '!=', '')
+                ->get();
             //filterization
             $data = $this->checkAlreadyPicked($list);
         } catch (\Exception $exception) {

--- a/app/Http/Controllers/API/v1/RequestLetterController.php
+++ b/app/Http/Controllers/API/v1/RequestLetterController.php
@@ -173,7 +173,11 @@ class RequestLetterController extends Controller
 
         try { 
             $list = Applicant::select('id', 'application_letter_number')
-                ->where('application_letter_number', 'LIKE', "%{$request->input('application_letter_number')}%")
+                ->where(function ($query) use ($request) {
+                    if ($request->filled('application_letter_number')) {
+                        $query->where('application_letter_number', 'LIKE', "%{$request->input('application_letter_number')}%");
+                    }
+                }) 
                 ->where('is_deleted', '!=', 1)
                 ->where('application_letter_number', '!=', '')
                 ->get();


### PR DESCRIPTION
Menghilangkan daftar surat permohonan yang tidak memiliki nomor surat permohonan pada API api/v1/application-letter/search-by-letter-number
![image](https://user-images.githubusercontent.com/19951241/88783984-b12ea300-d1b9-11ea-89cc-73bbcc7073d1.png)

response dari API diatas:
```
{
  "status": 200,
  "message": "success",
  "data": [
    {
      "id": 1358,
      "application_letter_number": "PLP/0124/PRWT/06/2020"
    }
  ]
}
```

detail: https://trello.com/c/R0CLqV7g/115-manajemen-surat-keluar-admin-dapat-membuat-surat-keluar