### PR TITLE
Error Ketika melakukan Pencarian Surat Permohonan berdasarkan Keyword Nomor Surat

### DIFF
--- a/app/Http/Controllers/API/v1/RequestLetterController.php
+++ b/app/Http/Controllers/API/v1/RequestLetterController.php
@@ -174,7 +174,7 @@ class RequestLetterController extends Controller
         $data = [];
 
         try { 
-            $list = Applicant::select('id', 'application_letter_number, verification_status')
+            $list = Applicant::select('id', 'application_letter_number', 'verification_status')
                 ->where(function ($query) use ($request) {
                     if ($request->filled('application_letter_number')) {
                         $query->where('application_letter_number', 'LIKE', "%{$request->input('application_letter_number')}%");


### PR DESCRIPTION
Perbaikan untuk error API Pencarian Surat Permohonan berdasarkan Keyword Nomor Surat

Contoh Error:
![image](https://user-images.githubusercontent.com/19951241/89283839-0b2adf00-d678-11ea-90f0-92ffe969912d.png)

Error di bagian code select yang seharusnya dipisahkan dengan koma (').
