### PR TITLE
Validasi ketika membuat Surat Keluar

### DIFF
--- a/app/Http/Controllers/API/v1/OutgoingLetterController.php
+++ b/app/Http/Controllers/API/v1/OutgoingLetterController.php
@@ -66,9 +66,14 @@ class OutgoingLetterController extends Controller
                 ]
             )
         );
+        
+        // Validasi Nomor Surat Keluar harus unik
+        $validLetterNumber = OutgoingLetter::where('letter_number', $request->input('letter_number'))->count();
 
         if ($validator->fails()) {
             return response()->format(422, $validator->errors());
+        } if ($validLetterNumber > 0) {
+            return response()->format(422, 'Nomor Surat Keluar sudah digunakan.');
         } else {
             DB::beginTransaction();
             try {

--- a/app/Http/Controllers/API/v1/OutgoingLetterController.php
+++ b/app/Http/Controllers/API/v1/OutgoingLetterController.php
@@ -68,11 +68,11 @@ class OutgoingLetterController extends Controller
         );
         
         // Validasi Nomor Surat Keluar harus unik
-        $validLetterNumber = OutgoingLetter::where('letter_number', $request->input('letter_number'))->count();
+        $validLetterNumber = OutgoingLetter::where('letter_number', $request->input('letter_number'))->exists();
 
         if ($validator->fails()) {
             return response()->format(422, $validator->errors());
-        } if ($validLetterNumber > 0) {
+        } if ($validLetterNumber) {
             return response()->format(422, 'Nomor Surat Keluar sudah digunakan.');
         } else {
             DB::beginTransaction();

--- a/app/Http/Controllers/API/v1/OutgoingLetterController.php
+++ b/app/Http/Controllers/API/v1/OutgoingLetterController.php
@@ -181,7 +181,7 @@ class OutgoingLetterController extends Controller
     {
         $response = [];
         foreach (json_decode($request->input('letter_request'), true) as $key => $value) {
-            $request_letter = RequestLetter::create(
+            $request_letter = RequestLetter::firstOrCreate(
                 [
                     'outgoing_letter_id' => $request->input('outgoing_letter_id'), 
                     'applicant_id' => $value['applicant_id']

--- a/app/Http/Controllers/API/v1/RequestLetterController.php
+++ b/app/Http/Controllers/API/v1/RequestLetterController.php
@@ -224,17 +224,13 @@ class RequestLetterController extends Controller
     {
         $response = [];
         foreach (json_decode($request->input('letter_request'), true) as $key => $value) {
-            $find = RequestLetter::where('applicant_id', '=', $value['applicant_id'])->first();
-            if (!$find) {
-
-                $request_letter = RequestLetter::create(
-                    [
+            $request_letter = RequestLetter::firstOrCreate(
+                [
                     'outgoing_letter_id' => $request->input('outgoing_letter_id'), 
                     'applicant_id' => $value['applicant_id']
-                    ]
-                );
-                $response[] = $request_letter;
-            }
+                ]
+            );
+            $response[] = $request_letter;
         }
 
         return $response;

--- a/app/Http/Controllers/API/v1/RequestLetterController.php
+++ b/app/Http/Controllers/API/v1/RequestLetterController.php
@@ -169,10 +169,19 @@ class RequestLetterController extends Controller
         return response()->format(200, 'success', ['id' => $id]);
     }
 
+    /**
+     * searchByLetterNumber function
+     *
+     * Menampilkan list surat permohonan yang belum didaftarkan di surat keluar.
+     * opsional, jika parameter request_letter_id dikirim, maka surat permohonan dengan ID tersebut akan tetap muncul di list
+     * 
+     * @param Request $request
+     * @return void
+     */
     public function searchByLetterNumber(Request $request)
     {
         $data = [];
-
+        $request_letter_ignore = $request->input('request_letter_id');
         try { 
             $list = Applicant::select('id', 'application_letter_number', 'verification_status')
                 ->where(function ($query) use ($request) {
@@ -185,7 +194,7 @@ class RequestLetterController extends Controller
                 ->where('application_letter_number', '!=', '')
                 ->get();
             //filterization
-            $data = $this->checkAlreadyPicked($list);
+            $data = $this->checkAlreadyPicked($list, $request_letter_ignore);
         } catch (\Exception $exception) {
             return response()->format(400, $exception->getMessage());
         }
@@ -240,13 +249,19 @@ class RequestLetterController extends Controller
      * This function is to check number letter already pick or not
      * return array of object
      */
-    public function checkAlreadyPicked($list)
+    public function checkAlreadyPicked($list, $request_letter_ignore)
     {
         $data = [];
         foreach ($list as $key => $value) {
-            $find = RequestLetter::where('applicant_id', $value['id'])->first();
-            if (!$find) {
+            if ($request_letter_ignore == $value['id']) {
                 $data[] = $value;
+            } else {
+                $find = RequestLetter::where('applicant_id', $value['id'])->first();                
+            $find = RequestLetter::where('applicant_id', $value['id'])->first();
+                $find = RequestLetter::where('applicant_id', $value['id'])->first();                
+                if (!$find) {
+                    $data[] = $value;
+                }
             }
         }
 

--- a/resources/views/email/logisticemailnotification.blade.php
+++ b/resources/views/email/logisticemailnotification.blade.php
@@ -1,5 +1,12 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>E-Mail PIKOBAR</title>
+</head>
+<body>
     <div>
         <div>Kepada Yth</div>
         <div>{{ $applicantName }}</div>
@@ -8,8 +15,6 @@
         <div>dari</div>
         <div>{{ $agency }}</div>
     </div>
-</head>
-<body>
     <div>
         <p>{{ $text }}</p>
         <p>{{ $note }}</p>


### PR DESCRIPTION
Revisi API Buat Surat Keluar:
- Validasi Nomor Surat Keluar tidak boleh sama / harus unik. Tertolak jika di database ada nomor surat keluar yang sama.
- Validasi Simpan Surat Permohonan dengan ID yang sama lebih dari satu, sehingga yang tersimpan hanya 1 walaupun array yang dikirim dengan ID yang sama lebih dari 1.

Modifikasi API Verifikasi Surat Permohonan
- Perubahan Struktur _Email Template_ ketika terverifikasi ataupun ditolak, agar  _HTML Friendly_.

Modifikasi API Pencarian Surat Permohonan
- Penambahan parameter request_letter_id, opsional. Jika dikirim, maka surat permohonan dengan ID tersebut akan tetap muncul di list

detail perubahan: 
- https://trello.com/c/R0CLqV7g/115-manajemen-surat-keluar-admin-dapat-membuat-surat-keluar
- https://trello.com/c/266gtU1f/150-permohonan-cek-status-permohonan-yang-ditolak-akan-dikirimkan-email-kepada-pemohon
- https://trello.com/c/mxwx5RYo/123-manajemen-surat-keluar-admin-dapat-menambahkan-mengedit-dan-menghapus-data-surat-permohonan-melalui-halaman-detail-surat-keluar