### PR TITLE
Error Update Realization fix - realization_unit set to null

### DIFF
--- a/database/migrations/2020_09_09_034018_change_realization_unit_to_null_to_logistic_realization_items_table.php
+++ b/database/migrations/2020_09_09_034018_change_realization_unit_to_null_to_logistic_realization_items_table.php
@@ -26,7 +26,7 @@ class ChangeRealizationUnitToNullToLogisticRealizationItemsTable extends Migrati
     public function down()
     {
         Schema::table('logistic_realization_items', function (Blueprint $table) {
-            //
+            $table->string('realization_unit', 30)->nullable(false)->change();
         });
     }
 }

--- a/database/migrations/2020_09_09_034018_change_realization_unit_to_null_to_logistic_realization_items_table.php
+++ b/database/migrations/2020_09_09_034018_change_realization_unit_to_null_to_logistic_realization_items_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ChangeRealizationUnitToNullToLogisticRealizationItemsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('logistic_realization_items', function (Blueprint $table) {
+            $table->string('realization_unit', 30)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('logistic_realization_items', function (Blueprint $table) {
+            //
+        });
+    }
+}


### PR DESCRIPTION
## Kendala
Error ketika Update Realisasi barang dengan mengubah status `Barang Belum Tersedia`. error yang muncul adalah `realization_unit` tidak bisa `null`. Itu dikarenakan request tidak mengirimkan `realization_unit` ke endpoint. Sehingga muncul error tersebut.

## Solusi
Membuat file migrasi yang dapat mengubah `realization_unit` menjadi `null`.