### PR TITLE
Bug Fix API Agency Statistic and Cities Statistic Filter by Date

### DIFF
--- a/app/Http/Controllers/API/v1/AreasController.php
+++ b/app/Http/Controllers/API/v1/AreasController.php
@@ -84,8 +84,8 @@ class AreasController extends Controller
 
     public function getCitiesTotalRequest(Request $request)
     {
-        $startDate = $request->filled('start_date') ? $request->input('start_date') : '2020-01-01';
-        $endDate = $request->filled('end_date') ? $request->input('end_date') : date('Y-m-d');
+        $startDate = $request->filled('start_date') ? $request->input('start_date') . ' 00:00:00' : '2020-01-01 00:00:00';
+        $endDate = $request->filled('end_date') ? $request->input('end_date') . ' 23:59:59' : date('Y-m-d H:i:s');
 
         try {
             $query = City::withCount([

--- a/app/Http/Controllers/API/v1/MasterFaskesTypeController.php
+++ b/app/Http/Controllers/API/v1/MasterFaskesTypeController.php
@@ -84,11 +84,11 @@ class MasterFaskesTypeController extends Controller
             ->orderBy('total', 'desc')
             ->firstOrFail();
 
-            $agency_total = Agency::select('agency_name')->join('applicants', 'applicants.agency_id', '=', 'agency.id')
+            $agency_total = Agency::select('agency_type')->join('applicants', 'applicants.agency_id', '=', 'agency.id')
             ->where('applicants.verification_status', Applicant::STATUS_VERIFIED)
             ->where('applicants.is_deleted', '!=', 1)
             ->whereBetween('agency.created_at', [$startDate, $endDate])
-            ->groupBy('agency_name')->get();
+            ->groupBy('agency_type')->get();
             $data = [
                 'total_agency' => count($agency_total),
                 'total_max' => $faskesType


### PR DESCRIPTION
# Dashboard
## API `logistic-request/cities/total-request`
- Bug data 0 semua ketika filter menggunakan tanggal
- Perbaikan dengan menambahkan `H:i:s` di value `$start_date` dan `$end_date`

## API `faskes-type-top-request`
- Fix mendefinisikan instansi berdasarkan `agency_type` bukan berdasarkan `agency_name`
- sehingga, contoh studi kasus di bawah ini
![image](https://user-images.githubusercontent.com/19951241/92737823-a6188680-f3a5-11ea-93b3-08abc7b88f6e.png)
- total instansi ada 3, yaitu Rumah Sakit, Masyarakat Umum, dan Klinik