### PR TITLE
API Pengembalian ke Tahapan sebelumnya

### DIFF
--- a/app/Applicant.php
+++ b/app/Applicant.php
@@ -192,4 +192,57 @@ class Applicant extends Model
         }
         return $applicant;
     }
+
+    static function undoStep($request)
+    {
+        $updateData = [];
+        switch ($request->step) {
+            case 'final':
+                $updateData = self::setNotYetFinalized($updateData);
+                $request['status'] = 'realisasi';
+                break;
+            case 'realisasi':
+                $updateData = self::setNotYetApproved($updateData);
+                $request['status'] = 'rekomendasi';
+                break;
+            case 'ditolak rekomendasi':
+                $updateData = self::setNotYetApproved($updateData);
+                $request['status'] = 'rekomendasi';
+                break;
+            default:
+                $updateData = self::setNotYetVerified($updateData);
+                $request['status'] = 'surat';
+                break;
+        }
+        $update = self::where('agency_id', '=', $request->id)->update($updateData);
+        return $request;
+    }
+
+    static function setNotYetFinalized($model) 
+    {
+        $model['finalized_by'] = null;
+        $model['finalized_at'] = null;
+        return $model;
+    }
+
+    static function setNotYetApproved($model) 
+    {
+        $model['approval_status'] = 'not_approved';
+        $model['approved_by'] = null;
+        $model['approved_at'] = null;
+        $model['approval_note'] = null;
+        $model = self::setNotYetFinalized($model);
+        return $model;
+    }
+
+    static function setNotYetVerified($model) 
+    {
+        $model['verification_status'] = 'not_verified';
+        $model['verified_by'] = null;
+        $model['verified_at'] = null;
+        $model['note'] = null;
+        $model = self::setNotYetApproved($model);
+        $model = self::setNotYetFinalized($model);
+        return $model;
+    }
 }

--- a/app/Http/Controllers/API/v1/LogisticRequestController.php
+++ b/app/Http/Controllers/API/v1/LogisticRequestController.php
@@ -583,4 +583,21 @@ class LogisticRequestController extends Controller
         }
         return $response;
     }
+
+    public function undoStep(Request $request)
+    {
+        $param = [
+            'id' => 'required|numeric',
+            'step' => 'required',
+            'url' => 'required'
+        ];
+        $response = Validation::validate($request, $param);
+        if ($response->getStatusCode() === 200) {
+            $request = Applicant::undoStep($request);
+            $request['agency_id'] = $request->id;
+            $whatsapp = $this->sendWhatsappNotification($request, $request['status']);
+            $response = response()->format(200, 'success', $request->all());
+        }
+        return $response;
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -105,6 +105,7 @@ Route::namespace('API\v1')->middleware('auth:api')->group(function () {
     Route::post('v1/logistic-request/letter/{id}', 'LogisticRequestController@uploadLetter');
     Route::post('v1/logistic-request/identity/{id}', 'LogisticRequestController@uploadApplicantFile');
     Route::post('v1/logistic-request/urgency', 'LogisticRequestController@urgencyChange');
+    Route::post('v1/logistic-request/return', 'LogisticRequestController@undoStep');
     Route::put('v1/logistic-request/{id}', 'LogisticRequestController@update');
     Route::post('v1/logistic-request/applicant-letter/{id}', 'LogisticRequestController@update');
     Route::post('v1/logistic-request/applicant-identity/{id}', 'LogisticRequestController@update');


### PR DESCRIPTION
URL: `api/v1/logistic-request/return`
Method: `POST`
Bearer Token: `YES`
Param:
- `id` : agency_id, contoh: `1588`
- `step` : posisi tahapan permohonannya , contoh: `ditolak verifikasi`
- `url` : site_url() dari web app, contoh: `https://logistik.pikobar.jabarprov.go.id/#`

Fungsionalitas:
- sistem akan memindahkan permohonan ke satu tahapan sebelumnya. Misalnya: 
   - Untuk permohonan dengan status Rekomendasi Salur -> Administrasi
   - Untuk permohonan dengan status Realisasi Salur -> Rekomendasi Salur
   - Untuk permohonan dengan status Ditolak (administrasi) -> Administrasi
   - Untuk permohonan dengan status Ditolak (Rekomendasi Salur) -> Rekomendasi Salur