### PR TITLE
API Daftar Laporan Penerimaan Barang - Bugfix double row record yang sama

### DIFF
--- a/app/Http/Controllers/API/v1/AcceptanceReportController.php
+++ b/app/Http/Controllers/API/v1/AcceptanceReportController.php
@@ -37,7 +37,9 @@ class AcceptanceReportController extends Controller
             ->searchReport($request)
             ->orderBy('acceptance_reports.date', 'desc')
             ->orderBy('agency.id', 'asc')
+            ->groupBy('acceptance_reports.agency_id', 'agency.id', 'agency.created_at')
             ->paginate($limit);
+
         return response()->json($data);
     }
 


### PR DESCRIPTION
Bug ini muncul ketika 1 permohonan logistik memiliki banyak (lebih dari 1) relasi dengan laporan penerimaan barang.
Contoh kasus:
Kode Permohonan Logistik 2148 memiliki 2 Laporan Penerimaan Barang, yaitu dengan id table 3 dan 5. 
Sehingga daftar yang muncul pada aplikasi ada 2 row Kode Permohonan 2148. 

![image](https://user-images.githubusercontent.com/19951241/112933488-2936d980-914a-11eb-9ad9-c1076e8bc09a.png)

Seharusnya 1 saja. Karena kebutuhan API ini hanya sebatas mendeteksi sudah ada laporan atau belum. 
Sedangkan untuk menampilkan relasinya bisa melalui API Detailnya (show) .

Maka ada kebutuhan group by `acceptance_reports.agency_id` di _Query Builder_nya