### PR TITLE
[Hotfix] Laporan penerimaan Barang - Kondisi 1 Permohonan hanya 1 Laporan Penerimaan & melepas format number dari BE yang menyebabkan error kuantitas barang yang dilaporkan

### DIFF
--- a/app/AcceptanceReport.php
+++ b/app/AcceptanceReport.php
@@ -16,11 +16,8 @@ class AcceptanceReport extends Model
         $param['note'] = 'required';
         $param['agency_id'] = 'required';
         $param['items'] = 'required';
-        $param['proof_picproof_pic'] = 'required';
-        $param['proof_picproof_pic_length'] = 'required';
-        $param['bast_proof'] = 'required';
+        $param['proof_pic_length'] = 'required';
         $param['bast_proof_length'] = 'required';
-        $param['item_proof'] = 'required';
         $param['item_proof_length'] = 'required';
         return $param;
     }

--- a/app/Http/Controllers/API/v1/AcceptanceReportController.php
+++ b/app/Http/Controllers/API/v1/AcceptanceReportController.php
@@ -13,7 +13,6 @@ use App\LogisticRealizationItems;
 use App\AcceptanceReport;
 use App\AcceptanceReportDetail;
 use App\FileUpload;
-use Carbon\Carbon;
 
 class AcceptanceReportController extends Controller
 {
@@ -47,26 +46,20 @@ class AcceptanceReportController extends Controller
     {
         $param = AcceptanceReport::setParamStore();
         $response = Validation::validate($request, $param);
-        if ($response->getStatusCode() == Response::HTTP_OK) {
-            $findReport = AcceptanceReport::where('agency_id', $request->agency_id)->first();
-            if ($findReport) {
-                $response = response()->format(Response::HTTP_UNPROCESSABLE_ENTITY, 'Permohonan dengan kode ' . $findReport->agency_id . ' sudah dilaporkan pada tanggal ' . Carbon::parse($findReport->date)->format('d-m-Y') . ' oleh ' . $findReport->fullname . '. Terima kasih sudah melaporkan penerimaan barang', $findReport);
-            } else {
-                DB::beginTransaction();
-                try {
-                    $acceptanceReport = $this->storeAcceptanceReport($request);
-                    $this->itemStore($request, $acceptanceReport);
-                    // Upload Seluruh File
-                    $proof_pic = $this->uploadAcceptanceFile($request, 'proof_pic');
-                    $bast_proof = $this->uploadAcceptanceFile($request, 'bast_proof');
-                    $item_proof = $this->uploadAcceptanceFile($request, 'item_proof');
-                    DB::commit();
-                    $response = response()->format(Response::HTTP_OK, 'success');
-                } catch (\Exception $exception) {
-                    DB::rollBack();
-                    $response = response()->format(Response::HTTP_UNPROCESSABLE_ENTITY, 'Error Insert Acceptance Report', $exception->getTrace());
-                }
-            }
+        abort_if($response->getStatusCode() != Response::HTTP_OK, $response);
+        DB::beginTransaction();
+        try {
+            $acceptanceReport = $this->storeAcceptanceReport($request);
+            $this->itemStore($request, $acceptanceReport);
+            // Upload Seluruh File
+            $proof_pic = $this->uploadAcceptanceFile($request, 'proof_pic');
+            $bast_proof = $this->uploadAcceptanceFile($request, 'bast_proof');
+            $item_proof = $this->uploadAcceptanceFile($request, 'item_proof');
+            DB::commit();
+            $response = response()->format(Response::HTTP_OK, 'success');
+        } catch (\Exception $exception) {
+            DB::rollBack();
+            $response = response()->format(Response::HTTP_UNPROCESSABLE_ENTITY, 'Error Insert Acceptance Report', $exception->getTrace());
         }
         return $response;
     }

--- a/app/LogisticRealizationItems.php
+++ b/app/LogisticRealizationItems.php
@@ -121,11 +121,6 @@ class LogisticRealizationItems extends Model
         return $value ? $value : 'PCS';
     }
 
-    public function getQtyAttribute($value)
-    {
-        return number_format($value, 0, ",", ".");
-    }
-
     static function storeData($store_type)
     {
         DB::beginTransaction();

--- a/app/LogisticRealizationItems.php
+++ b/app/LogisticRealizationItems.php
@@ -10,7 +10,7 @@ use JWTAuth;
 class LogisticRealizationItems extends Model
 {
     use SoftDeletes;
-    
+
     const STATUS = [
         'delivered',
         'not_delivered',
@@ -71,7 +71,7 @@ class LogisticRealizationItems extends Model
             'data' => $id
         ];
         DB::beginTransaction();
-        try {   
+        try {
             $deleteRealization = self::where('id', $id)->delete();
             DB::commit();
             $result = [
@@ -205,7 +205,7 @@ class LogisticRealizationItems extends Model
         $data = self::selectList();
         $data = self::withPICData($data);
         $data = $data->whereNotNull('created_by')
-            ->orderBy('logistic_realization_items.id') 
+            ->orderBy('logistic_realization_items.id')
             ->where('logistic_realization_items.agency_id', $request->agency_id)->paginate($limit);
         $logisticItemSummary = self::where('agency_id', $request->agency_id)->sum('realization_quantity');
         $data->getCollection()->transform(function ($item, $key) use ($logisticItemSummary) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -193,6 +193,6 @@ Route::namespace('API\v1')->prefix('v1')->group(function () {
         Route::post('/notify', 'ChangeStatusNotifyController@sendNotification');
 
         // API Acceptance Reports
-        Route::apiResource('/acceptance-report', 'AcceptanceReportController');
+        Route::apiResource('/acceptance-report', 'AcceptanceReportController')->except('store');
     });
 });


### PR DESCRIPTION
## Pemohon hanya bisa melaporkan penerimaan barang satu kali, sehingga bila melaporkan kedua kali muncul informasi sudah melaporkan
- Jika barang yang diterima sudah dilaporkan, maka muncul pop up pada saat cek kode barang bahwa barang sudah dilaporkan
- Redaksi yang muncul pada popup yaitu: "Permohonan dengan kode xxxx sudah dilaporkan pada tanggal xx-xx-xxxx. Terima kasih sudah melaporkan penerimaan barang"

## [Hotfix] Melepas format number dari BE yang menyebabkan error kuantitas barang yang dilaporkan

Bug muncul ketika kuantitas barang >= 1000. Karena return dari BE adalah sudah terformat menjadi 1.000. Yang akbiatnya dibaca desimal oleh FE

dan di FE ada perhitungan otomatisnya ketika melaporkan barang yang tidak layak dan tidak berdasarkan kuantitas barang tersebut.

Maka solusinya format number dilepas di BE. dan apabila di FE membutuhkan formatting, bisa dilakukan langsung oleh FE.