### PR TITLE
Poslog integration - Update Master Faskes & API Update Otomatis Seluruh Data Outbounds

### DIFF
--- a/app/Http/Controllers/API/v1/OutboundController.php
+++ b/app/Http/Controllers/API/v1/OutboundController.php
@@ -38,4 +38,9 @@ class OutboundController extends Controller
         }
         return $response;
     }
+
+    public function mapFaskesPoslog(Request $request)
+    {
+        return WmsJabar::mapFaskesPoslog($request);
+    }
 }

--- a/app/Http/Controllers/API/v1/OutboundController.php
+++ b/app/Http/Controllers/API/v1/OutboundController.php
@@ -39,8 +39,8 @@ class OutboundController extends Controller
         return $response;
     }
 
-    public function mapFaskesPoslog(Request $request)
+    public function updateAll(Request $request)
     {
-        return WmsJabar::mapFaskesPoslog($request);
+        return WmsJabar::updateAll($request);
     }
 }

--- a/app/MasterFaskes.php
+++ b/app/MasterFaskes.php
@@ -24,6 +24,9 @@ class MasterFaskes extends Model
         'is_imported',
         'point_latitude_longitude',
         'non_medical',
+        'kode_kab_kemendagri',
+        'nama_kab',
+        'alamat',
         'is_reference'
     ];
 

--- a/app/Outbound.php
+++ b/app/Outbound.php
@@ -15,6 +15,7 @@ class Outbound extends Model
         'lo_issued_by',
         'lo_ct',
         'send_to_id',
+        'send_to_extid',
         'send_to_name',
         'send_to_address',
         'city_id',

--- a/app/WmsJabar.php
+++ b/app/WmsJabar.php
@@ -133,6 +133,22 @@ class WmsJabar extends Usage
         return $response;
     }
 
+    static function mapFaskesPoslog(Request $request)
+    {
+        try {
+            $map = Outbound::all()->reject(function ($user) {
+                return $user->send_to_extid === false;
+            })->map(function ($outbound) use ($request) {
+                $request->merge(['request_id' => $outbound->req_id]);
+                $update[] = self::getOutboundById($request);
+            });
+            $response = response()->format(Response::HTTP_OK, 'success');
+        } catch (\Exception $exception) {
+            $response = response()->format(Response::HTTP_UNPROCESSABLE_ENTITY, $exception->getMessage(), $exception->getTrace());
+        }
+        return $response;
+    }
+
     static function updateFaskes($outboundPlan)
     {
         return MasterFaskes::where('id', $outboundPlan['send_to_extid'])->update([

--- a/app/WmsJabar.php
+++ b/app/WmsJabar.php
@@ -133,7 +133,7 @@ class WmsJabar extends Usage
         return $response;
     }
 
-    static function mapFaskesPoslog(Request $request)
+    static function updateAll(Request $request)
     {
         try {
             $map = Outbound::all()->reject(function ($user) {

--- a/database/migrations/2021_04_12_043557_add_send_to_extid_to_outbounds_table.php
+++ b/database/migrations/2021_04_12_043557_add_send_to_extid_to_outbounds_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSendToExtidToOutboundsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('outbounds', function (Blueprint $table) {
+            $table->string('send_to_extid', 11)->after('send_to_id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('outbounds', function (Blueprint $table) {
+            $table->dropColumn('send_to_extid');
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -86,7 +86,7 @@ Route::namespace('API\v1')->prefix('v1')->group(function () {
         Route::get('/outbound-notification', 'OutboundController@notification');
         Route::get('/sendping', 'OutboundController@sendPing');
         Route::get('/poslog-notify', 'OutboundController@getNotification');
-        Route::get('/map-faskes-poslog', 'OutboundController@mapFaskesPoslog');
+        Route::get('/update-all-lo', 'OutboundController@updateAll');
     });
 
     Route::middleware('auth:api')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -86,6 +86,7 @@ Route::namespace('API\v1')->prefix('v1')->group(function () {
         Route::get('/outbound-notification', 'OutboundController@notification');
         Route::get('/sendping', 'OutboundController@sendPing');
         Route::get('/poslog-notify', 'OutboundController@getNotification');
+        Route::get('/map-faskes-poslog', 'OutboundController@mapFaskesPoslog');
     });
 
     Route::middleware('auth:api')->group(function () {


### PR DESCRIPTION
## Update Master Faskes
- Menambahkan `send_to_extid` di tabel outbounds, karena ada penambahan atribut dari Poslog.
- menambahkan fitur _update_ data faskes yang dari Poslog ketika menyimpan & meng_update_ data `outbounds`
- Data yang diupdate yaitu:
   - `poslog_id`, ID Customer Poslog
   - `poslog_name`, Nama Customer Poslog
   - `alamat`, alamat faskes
   - `kode_kab_kemendagri`, ID Kabkot versi Kemendagri
   - `nama_kab`, nama Kabkot

## API Update Otomatis Seluruh Data Outbounds (di Logistik) dengan Data Outbounds (di Poslog)
- API yang digunakan untuk mengupdate seluruh data outbounds di Logistik
- API ini mendapatkan seluruh LO_ID yang kemudian di request seluruh LO_ID tersebut ke Poslog untuk updatenya.