### PR TITLE
API Statistik Laporan Penerimaan Logistik

### DIFF
--- a/app/Agency.php
+++ b/app/Agency.php
@@ -164,6 +164,14 @@ class Agency extends Model
             $query->whereBetween('acceptance_reports.date', [$request->input('start_date'), $request->input('end_date')]);
         });
 
+        $query->when($request->has('status'), function ($query) use ($request) {
+            $query->when($request->input('status') == 1, function ($query) use ($request) {
+                $query->has('acceptanceReport');
+            }, function ($query) {
+                $query->doesntHave('acceptanceReport');
+            });
+        });
+
         return $query;
     }
 

--- a/app/Agency.php
+++ b/app/Agency.php
@@ -133,6 +133,13 @@ class Agency extends Model
         });
     }
 
+    public function scopeFinal($query)
+    {
+        return $query->whereHas('applicant', function ($query) {
+            $query->whereNotNull('finalized_by')->where('is_deleted', '!=' , 1);
+        });
+    }
+
     /**
      * Search Report Scope function
      *

--- a/app/Agency.php
+++ b/app/Agency.php
@@ -151,7 +151,7 @@ class Agency extends Model
      */
     public function scopeSearchReport($query, $request)
     {
-        return $query->when($request->has('search'), function ($query) use ($request) {
+        $query->when($request->has('search'), function ($query) use ($request) {
             $query->where(function ($query) use ($request) {
                 $query->where('agency.id', 'LIKE', "%{$request->input('search')}%")
                       ->orWhereHas('applicant', function ($query) use ($request) {
@@ -159,6 +159,12 @@ class Agency extends Model
                 });
             });
         });
+
+        $query->when($request->input('start_date') && $request->input('end_date'), function ($query) use ($request) {
+            $query->whereBetween('acceptance_reports.date', [$request->input('start_date'), $request->input('end_date')]);
+        });
+
+        return $query;
     }
 
     static function whereStatusCondition($data, $request)

--- a/app/Http/Controllers/API/v1/AcceptanceReportController.php
+++ b/app/Http/Controllers/API/v1/AcceptanceReportController.php
@@ -143,4 +143,15 @@ class AcceptanceReportController extends Controller
         $response = response()->format(Response::HTTP_OK, 'success', $data);
         return $response;
     }
+
+    public function statistic(Request $request)
+    {
+        $alreadyReportedTotal = Agency::final()->has('acceptanceReport')->count();
+        $notYetReportedTotal = Agency::final()->doesntHave('acceptanceReport')->count();
+        $statistic = [
+            'already_reported_total' => $alreadyReportedTotal,
+            'not_yet_reported_total' => $notYetReportedTotal
+        ];
+        return response()->format(Response::HTTP_OK, 'success', $statistic);
+    }
 }

--- a/app/Http/Controllers/API/v1/AcceptanceReportController.php
+++ b/app/Http/Controllers/API/v1/AcceptanceReportController.php
@@ -26,19 +26,15 @@ class AcceptanceReportController extends Controller
     public function index(Request $request)
     {
         $limit = $request->input('limit', 10);
-        $request->request->add(['verification_status' => Applicant::STATUS_VERIFIED]);
-        $request->request->add(['approval_status' => Applicant::STATUS_APPROVED]);
-        $request->request->add(['finalized_by' => Applicant::STATUS_FINALIZED]);
-
         $data = Agency::select('agency.id', 'agency.created_at')
-            ->with(['applicant', 'AcceptanceReport']);
-        $data = Agency::whereHasApplicant($data, $request)
-            ->leftJoin('acceptance_reports', 'agency.id', '=', 'acceptance_reports.agency_id')
-            ->searchReport($request)
-            ->orderBy('acceptance_reports.date', 'desc')
-            ->orderBy('agency.id', 'asc')
-            ->groupBy('acceptance_reports.agency_id', 'agency.id', 'agency.created_at', 'acceptance_reports.date')
-            ->paginate($limit);
+                        ->final()
+                        ->with('applicant', 'AcceptanceReport')
+                        ->leftJoin('acceptance_reports', 'agency.id', '=', 'acceptance_reports.agency_id')
+                        ->searchReport($request)
+                        ->orderBy('acceptance_reports.date', 'desc')
+                        ->orderBy('agency.id', 'asc')
+                        ->groupBy('acceptance_reports.agency_id', 'agency.id', 'agency.created_at', 'acceptance_reports.date')
+                        ->paginate($limit);
 
         return response()->json($data);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -197,5 +197,6 @@ Route::namespace('API\v1')->prefix('v1')->group(function () {
         Route::apiResource('/acceptance-report', 'AcceptanceReportController')->except('store');
         Route::apiResource('/acceptance-report-detail', 'AcceptanceReportDetailController');
         Route::apiResource('/acceptance-report-evidence', 'AcceptanceReportEvidenceController');
+        Route::get('/acceptance-report-statistic', 'AcceptanceReportController@statistic');
     });
 });


### PR DESCRIPTION
## API Daftar Laporan Penerimaan Logistik
- Filter tanggal berupa range tanggal dari tanggal awal (`start_date`) sampai akhir (`end_date`) yang didapatkan dari tanggal yang awal dan akhir pelaporan penerimaan 
- Filter status (`status`) permohonan sudah lapor (value `1`) atau belum (value `0`)

## API Statistik Laporan Penerimaan Logistik
- Statistik penerimaan barang dihitung dari pemohon yang sudah submit pelaporan penerimaan barang
- Statistik permohonan yang belum melaporkan dapat ditampilkan diatas daftar permohonan

https://trello.com/c/qIaYHsgl/357-2145-laporan-penerimaan-sp-1-admin-dan-pic-dapat-melihat-statistik-permohonan-yang-sudah-melaporkan-dan-belum-melaporkan