### PR TITLE
[Bugfix] Bug at API incoming-letter at filterization + Deployment Setup Change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,47 @@
-FROM alpine:3.13
+FROM registry.digitalservice.id/proxyjds/library/alpine:3.13
 
 LABEL Maintainer="Jabar Digital Service <digital.service@jabarprov.go.id>" \
     Description="Lightweight container with Nginx 1.16 & PHP-FPM 7.4 based on Alpine Linux (forked from trafex/alpine-nginx-php7)."
-
-ARG PHP_VERSION="7.4.15-r0"
 
 # Fix iconv issue when generate pdf
 RUN apk --no-cache add --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ gnu-libiconv
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
 
 # Install packages
-RUN apk --no-cache add nano php7=${PHP_VERSION} php7-fpm php7-opcache php7-phar php7-openssl php7-gd php7-ctype php7-curl php7-dom \
-    php7-iconv php7-intl php7-json php7-mbstring php7-pdo_mysql php7-pdo_sqlite php7-session php7-simplexml php7-tokenizer php7-fileinfo php7-xml php7-xmlreader php7-xmlwriter \
-    php7-zip php7-zlib php7-sodium php7-posix php7-pcntl nginx supervisor curl && \
-    rm /etc/nginx/conf.d/default.conf
+RUN apk --no-cache add \
+    nano \
+    php7-fpm \
+    php7-opcache \
+    php7-phar \
+    php7-openssl \
+    php7-gd \
+    php7-ctype \
+    php7-curl \
+    php7-dom \
+    php7-iconv \
+    php7-intl \
+    php7-json \
+    php7-mbstring \
+    php7-pdo_mysql \
+    php7-pdo_sqlite \
+    php7-session \
+    php7-simplexml \
+    php7-tokenizer \
+    php7-fileinfo \
+    php7-xml \
+    php7-xmlreader \
+    php7-xmlwriter \
+    php7-zip \
+    php7-zlib \
+    php7-sodium \
+    php7-posix \
+    php7-pcntl \
+    nginx \
+    supervisor \
+    curl
+
+# Remove default.conf nginx
+RUN rm /etc/nginx/conf.d/default.conf
 
 # Configure nginx
 COPY docker-config/nginx.conf /etc/nginx/nginx.conf
@@ -28,6 +56,10 @@ COPY docker-config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Setup document root
 RUN mkdir -p /var/www/html
 
+# Set Docker App only available run as app, queue, scheduler
+ARG DOCKER_APP
+ENV DOCKER_APP ${DOCKER_APP}
+
 # Make sure files/folders needed by the processes are accessable when they run under the nobody user
 RUN chown -R nobody.nobody /var/www/html && \
     chown -R nobody.nobody /run && \
@@ -40,9 +72,15 @@ USER nobody
 # Add application
 WORKDIR /var/www/html
 COPY --chown=nobody . /var/www/html/
-COPY --from=composer:2.0.9 /usr/bin/composer /usr/local/bin/composer
 
-RUN php /usr/local/bin/composer install --no-dev --optimize-autoloader
+# Install composer
+COPY --from=registry.digitalservice.id/proxyjds/library/composer:2.0.9 /usr/bin/composer /usr/bin/composer
+
+# Run composer install to install the dependencies
+RUN composer install --no-cache --no-dev --optimize-autoloader --prefer-dist --no-interaction --no-progress
+
+# Permission docker-entrypoint
+RUN chmod +x docker-config/docker-entrypoint.sh
 
 # Expose the port nginx is reachable on
 EXPOSE 8080

--- a/Dockerfile.jacloud
+++ b/Dockerfile.jacloud
@@ -12,18 +12,22 @@ ENV MAX_UPLOAD_SIZE 10M
 
 RUN apt-get update && apt-get install mysql-client -y
 
-RUN php composer.phar install
+# Install composer
+COPY --from=registry.digitalservice.id/proxyjds/library/composer:2.0.9 /usr/bin/composer /usr/bin/composer
+
+RUN composer install --no-dev
+
 RUN chown -R www-data:www-data \
         /var/www/html/storage \
         /var/www/html/bootstrap \
         && chmod -R 777 /var/www/html/storage \
         /var/www/html/bootstrap
-        
+
 COPY docker/php/php.ini /usr/local/etc/php/php.ini
 
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \
     && sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
-  
+
 EXPOSE 80
 
 ENTRYPOINT [ "sh","docker/docker-entrypoint.sh" ]

--- a/app/IncomingLetter.php
+++ b/app/IncomingLetter.php
@@ -49,18 +49,22 @@ class IncomingLetter extends Model
     static function whereList(Request $request, $data)
     {
         return $data->where(function ($query) use ($request) {
-            if ($request->has('letter_date')) {
+            $query->when($request->input('letter_date'), function ($query) use ($request) {
                 $query->whereRaw("DATE(applicants.created_at) = '" . $request->input('letter_date') . "'");
-            }
-            if ($request->has('district_code')) {
+            });
+
+            $query->when($request->input('district_code'), function ($query) use ($request) {
                 $query->where('agency.location_district_code', '=', $request->input('district_code'));
-            }
-            if ($request->has('agency_type')) {
+            });
+
+            $query->when($request->input('agency_type'), function ($query) use ($request) {
                 $query->where('agency.agency_type', '=', $request->input('agency_type'));
-            }
-            if ($request->has('letter_number')) {
+            });
+
+            $query->when($request->input('letter_number'), function ($query) use ($request) {
                 $query->where('applicants.application_letter_number', 'LIKE', "%{$request->input('letter_number')}%");
-            }
+            });
+
             if ($request->has('mail_status')) {
                 if ($request->input('mail_status') === 'exists') {
                     $query->whereNotNull('request_letters.id');

--- a/app/LogisticRequest.php
+++ b/app/LogisticRequest.php
@@ -242,9 +242,6 @@ class LogisticRequest extends Model
         $param['step'] = 'finalized';
         $param['phase'] = 'final';
         $response = self::getResponseApproval($request, $param);
-        if ($response->getStatusCode() === Response::HTTP_OK) {
-            $response = WmsJabar::sendPing();
-        }
         return $response;
     }
 

--- a/app/LogisticRequest.php
+++ b/app/LogisticRequest.php
@@ -242,6 +242,9 @@ class LogisticRequest extends Model
         $param['step'] = 'finalized';
         $param['phase'] = 'final';
         $response = self::getResponseApproval($request, $param);
+        if ($response->getStatusCode() == Response::HTTP_OK) {
+            $response = WmsJabar::sendPing();
+        }
         return $response;
     }
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b40da7346478bf1e4199c6d7c1e5c324",
+    "content-hash": "178a2fc6c941210be5f21bc5a9441ff1",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -10,7 +10,7 @@ do
     echo "Waiting for database connection ..."
 done
 
-php composer.phar dump-autoload
+composer dump-autoload
 php artisan config:clear
 php artisan cache:clear
 php artisan route:clear


### PR DESCRIPTION
# [Bugfix] Bug at API incoming-letter at filterization
Bug shown up when Endpoint `api/v1/imcoming-letter` get parameter `district_code` but empty / null value.
This is because wrong condition in query. We should not use `$request->has('district_code')` if that param still send by Frontend. This case is solved by change `$request->has()` to `$request->input`.
if ($request->has('district_code'))  ==> return true, if parameter sent and whatever value, include null
if ($request->input('district_code')) ==> return true, if parameter sent and value is not null

# Deployment Setup Change
Change Depedency alpine and composer to registry digitalservice

# Version Note
v1.2.4