### PR TITLE
Bug Fix - Counting Final Items Qty total

### DIFF
--- a/app/Http/Controllers/API/v1/OutgoingLetterController.php
+++ b/app/Http/Controllers/API/v1/OutgoingLetterController.php
@@ -225,7 +225,11 @@ class OutgoingLetterController extends Controller
             'final_unit',
             'material_group',
             'soh_location_name'
-        )->orderBy('agency_name', 'final_product_id', 'final_product_name')->get();
+        )
+        ->orderBy('agency_name')
+        ->orderBy('final_product_id')
+        ->orderBy('final_product_name')
+        ->get();
         return $data;
     }
 }

--- a/app/Http/Controllers/API/v1/RequestLetterController.php
+++ b/app/Http/Controllers/API/v1/RequestLetterController.php
@@ -156,16 +156,16 @@ class RequestLetterController extends Controller
     {
         $realization_total = LogisticRealizationItems::where('agency_id', $request_letter->agency_id)
         ->where('applicant_id', $request_letter->applicant_id)
-        ->sum('realization_quantity');
+        ->sum('final_quantity');
 
 
         $realization = LogisticRealizationItems::where('agency_id', $request_letter->agency_id)
         ->where('applicant_id', $request_letter->applicant_id)
-        ->whereNotNull('realization_date')
+        ->whereNotNull('final_date')
         ->first();
 
         $request_letter->realization_total = $realization_total;
-        $request_letter->realization_date = $realization['realization_date'];
+        $request_letter->realization_date = $realization['final_date'];
 
         $data = $request_letter;
         return $data;


### PR DESCRIPTION
# Bug Fix - Counting Final Items Qty total
- Bug count final quantity items because wrong fields.

# Error Fix - Export Outgoing Letter to PDF
- Error because orderBy() query builder code still use laravel 5.7 rule. Change to orderBy() per single fields. [source](https://laravel.com/docs/7.x/queries#ordering-grouping-limit-and-offset)

# References
- https://trello.com/c/sS8sxwgv/428-isu-di-surat-perintah-jumlah-item-tidak-sama-pada-detail-surat-perintah-dan-print-out-surat-perintah