### PR TITLE
Error Fix Seeder File - Add columns when INSERT data of products

### DIFF
--- a/database/seeds/data/product.sql
+++ b/database/seeds/data/product.sql
@@ -1,4 +1,4 @@
-INSERT INTO `products` VALUES (1,'ABN',NULL,1,'ABN',NULL,NULL,0,NULL,NULL),
+INSERT INTO `products` (id, name, description, material_group_status, material_group, total_stock, total_used, is_imported, created_at, updated_at) VALUES (1,'ABN',NULL,1,'ABN',NULL,NULL,0,NULL,NULL),
 (2,'Alcohol One Swab',NULL,1,'ALCOHOL ONE SWAB',NULL,NULL,0,NULL,NULL),
 (3,'Alcohol Swab',NULL,1,'ALCOHOL_SWAB',NULL,NULL,0,NULL,NULL),
 (4,'Antiseptik',NULL,1,'ANTISEPTIK',NULL,NULL,0,NULL,NULL),


### PR DESCRIPTION
Error:
- In this seeder and in existing table migration did not same count of columns. So add columns when insert needed

https://github.com/jabardigitalservice/pikobar-logistik-api/issues/267