### PR TITLE
Allocation Vaccine - Add Total of Distribution Requests & Total of Allocation Material Qty

### DIFF
--- a/app/AllocationRequest.php
+++ b/app/AllocationRequest.php
@@ -6,6 +6,14 @@ use Illuminate\Database\Eloquent\Model;
 
 class AllocationRequest extends Model
 {
+    protected $appends = ['allocation_material_requests_total'];
+
+    public function getAllocationMaterialRequestsTotalAttribute($value)
+    {
+        $totalQtyMaterialRequested = AllocationMaterialRequest::where('allocation_request_id', $this->id)->sum('qty');
+        return $totalQtyMaterialRequested;
+    }
+
     public function allocationDistributionRequests()
     {
         return $this->hasMany('App\AllocationDistributionRequest');

--- a/app/Http/Controllers/API/v1/AllocationVaccineRequestController.php
+++ b/app/Http/Controllers/API/v1/AllocationVaccineRequestController.php
@@ -14,6 +14,7 @@ class AllocationVaccineRequestController extends Controller
         $limit = $request->input('limit', 10);
         $data = AllocationRequest::where('type', 'vaccine')
             ->with(['allocationDistributionRequests', 'allocationMaterialRequests'])
+            ->withCount(['allocationDistributionRequests'])
             ->paginate($limit);
         return response()->format(Response::HTTP_OK, 'success', $data);
     }
@@ -22,6 +23,7 @@ class AllocationVaccineRequestController extends Controller
     {
         $data = AllocationRequest::where('type', 'vaccine')
             ->with(['allocationDistributionRequests', 'allocationMaterialRequests'])
+            ->withCount(['allocationDistributionRequests'])
             ->find($id);
         return response()->format(Response::HTTP_OK, 'success', $data);
     }

--- a/database/migrations/2021_09_23_043748_add_note_number_service_column_to_allocation_requests_table.php
+++ b/database/migrations/2021_09_23_043748_add_note_number_service_column_to_allocation_requests_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddNoteNumberServiceColumnToAllocationRequestsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('allocation_requests', function (Blueprint $table) {
+            $table->string('note_number_service')->nullable()->after('letter_number');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('allocation_requests', function (Blueprint $table) {
+            $table->dropColumn('note_number_service');
+        });
+    }
+}


### PR DESCRIPTION
## Description
- Add Total of Distribution Requests. Get from counting relation to `allocation_distribution_requests` table
- Add total of allocation material. Get from sum of qty of `allocation_material_requests` where `allocation_request_id` is `$this->id`
- https://airtable.com/appMJE57FaKQcEUwA/tbl6no9dhW3sDRJhb/viwittlbwGyGABPNQ/recMQXgoChDbFmAlA?blocks=hide
## Evidence
title: Allocation Vaccine - Add Total of Distribution Requests & Total of Allocation Material Qty
project: Pikobar Logistik
participants: @budiaramdhanrindi @firmanalamsyah580 @f1reFr0st @novansyaah @rizkyrmsyah