### PR TITLE
Allocation vaccine - Several Change to adapt Spreadsheet template update

### DIFF
--- a/app/Http/Controllers/API/v1/ImportAllocationVaccineRequestController.php
+++ b/app/Http/Controllers/API/v1/ImportAllocationVaccineRequestController.php
@@ -66,7 +66,7 @@ class ImportAllocationVaccineRequestController extends Controller
                                 'material_id' => $allocations[10][$column],
                                 'material_name' => $allocations[12][$column],
                                 'qty' => $allocations[$index][$column] ?? 0,
-                                'UoM' => $allocationMaterial->UoM,
+                                'UoM' => optional($allocationMaterial)->UoM ?? 'PCS',
                             ]);
                         }
                     }

--- a/app/Http/Controllers/API/v1/ImportAllocationVaccineRequestController.php
+++ b/app/Http/Controllers/API/v1/ImportAllocationVaccineRequestController.php
@@ -37,7 +37,7 @@ class ImportAllocationVaccineRequestController extends Controller
                 'type' => 'vaccine',
                 'applicant_name' => $allocations[3][0],
                 'applicant_position' => $allocations[4][0],
-                'applicant_agency_id' => MasterFaskes::where('poslog_id', $allocations[5][0])->value('id'),
+                'applicant_agency_id' => $allocations[5][0],
                 'applicant_agency_name' => $allocations[6][0],
                 'distribution_description' => $allocations[7][0],
                 'letter_url' => $allocations[8][0],
@@ -50,7 +50,7 @@ class ImportAllocationVaccineRequestController extends Controller
                 if ($allocations[$index][1]) {
                     $allocationDistributionRequest = AllocationDistributionRequest::create([
                         'allocation_request_id' => $allocationRequest->id,
-                        'agency_id' => MasterFaskes::where('poslog_id', $allocations[$index][1])->value('id'),
+                        'agency_id' => $allocations[$index][1],
                         'agency_name' => $allocations[$index][0],
                         'distribution_plan_date' => Carbon::instance(Date::excelToDateTimeObject($allocations[$index][8])),
                     ]);

--- a/app/Http/Controllers/API/v1/ImportAllocationVaccineRequestController.php
+++ b/app/Http/Controllers/API/v1/ImportAllocationVaccineRequestController.php
@@ -10,10 +10,11 @@ use App\Enums\AllocationRequestStatusEnum;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ImportExcelRequest;
 use App\Imports\MultipleSheetImport;
-use App\MasterFaskes;
+use Carbon\Carbon;
 use Illuminate\Http\Response;
 use Maatwebsite\Excel\Facades\Excel;
 use DB;
+use PhpOffice\PhpSpreadsheet\Shared\Date;
 
 class ImportAllocationVaccineRequestController extends Controller
 {
@@ -32,7 +33,7 @@ class ImportAllocationVaccineRequestController extends Controller
 
             $allocationRequest = AllocationRequest::create([
                 'letter_number' => $allocations[1][0],
-                'letter_date' => $allocations[2][0],
+                'letter_date' => Carbon::instance(Date::excelToDateTimeObject($allocations[2][0])),
                 'type' => 'vaccine',
                 'applicant_name' => $allocations[3][0],
                 'applicant_position' => $allocations[4][0],
@@ -51,7 +52,7 @@ class ImportAllocationVaccineRequestController extends Controller
                         'allocation_request_id' => $allocationRequest->id,
                         'agency_id' => MasterFaskes::where('poslog_id', $allocations[$index][1])->value('id'),
                         'agency_name' => $allocations[$index][0],
-                        'distribution_plan_date' => $allocations[$index][8],
+                        'distribution_plan_date' => Carbon::instance(Date::excelToDateTimeObject($allocations[$index][8])),
                     ]);
 
                     for ($column = 0; $column < count($allocations[10])-1; $column++) {


### PR DESCRIPTION
## Changes
API Import Allocation Vaccine
- Formatting/converting Serial Date Excel/Spreadsheet to YYYY-MM-DD
- Change Relationing to `agency_id` from `poslog_id` to `id`
- Add optional() method for conditioning UoM `null`

## References
- Formatting/converting Serial Date Excel/Spreadsheet to YYYY-MM-DD https://stackoverflow.com/questions/50481950/laravel-excel-is-converting-dates-from-heading-into-some-numbers/55139981#55139981
- How does Laravel optional() work? https://stackoverflow.com/questions/49937885/how-does-laravel-optional-work

## Evidence
project: Pikobar Logistik
title: Allocation vaccine - Several Change to adapt Spreadsheet template update
participants: @rindibudiaramdhan @sandisunandar99 @tukangremot @rizkyrmsyah @indraprasetya154 @setiadijoe @rachadiannovansyah @ayocodingit 

cc: @jabardigitalservice/jds-backend 