### PR TITLE
Master Faskes Service - Bug `is_paginated` & Filtering Updates

### DIFF
--- a/app/Http/Controllers/API/v1/AllocationMaterialController.php
+++ b/app/Http/Controllers/API/v1/AllocationMaterialController.php
@@ -12,7 +12,7 @@ class AllocationMaterialController extends Controller
 {
     public function index(GetAllocationMaterialRequest $request)
     {
-        $isPaginated = $request->input('is_paginated', 0);
+        $isPaginated = $request->input('is_paginated', 1);
         $type = $request->input('type', 'vaccine');
         $limit = $request->input('limit', 10);
         $data = AllocationMaterial::where('type', $type)
@@ -22,7 +22,7 @@ class AllocationMaterialController extends Controller
                     $query->where('matg_id', $request->input('matg_id'));
                 });
 
-        $data = $isPaginated ? $data->get() : $data->paginate($limit);
+        $data = $isPaginated ? $data->paginate($limit) : $data->get();
         return response()->format(Response::HTTP_OK, 'success', $data);
     }
 

--- a/app/Http/Controllers/API/v1/MasterFaskesController.php
+++ b/app/Http/Controllers/API/v1/MasterFaskesController.php
@@ -19,7 +19,7 @@ class MasterFaskesController extends Controller
     {
         $limit = $request->input('limit', 20);
         $sort = $this->getValidOrderDirection($request->input('sort'));
-        $isPaginated = $request->input('is_paginated', 0);
+        $isPaginated = $request->input('is_paginated', 1);
 
         $data = MasterFaskes::with('masterFaskesType')
                 ->where(function ($query) use ($request) {
@@ -40,7 +40,7 @@ class MasterFaskesController extends Controller
                 })
                 ->orderBy('nama_faskes', $sort);
 
-        $data = $isPaginated ? $data->select('id', 'nama_faskes')->get() : $data->paginate($limit);
+        $data = $isPaginated ? $data->paginate($limit) : $data->select('id', 'nama_faskes')->get();
 
         return response()->format(Response::HTTP_OK, 'success', $data);
     }

--- a/app/Http/Controllers/API/v1/MasterFaskesController.php
+++ b/app/Http/Controllers/API/v1/MasterFaskesController.php
@@ -29,6 +29,13 @@ class MasterFaskesController extends Controller
                     ->when($request->has('id_tipe_faskes'), function ($query) use ($request) {
                         $query->where('master_faskes.id_tipe_faskes', '=', $request->input('id_tipe_faskes'));
                     })
+                    ->when($request->has('is_faskes'), function ($query) use ($request) {
+                        $query->when($request->input('is_faskes'), function ($query) use ($request) {
+                            $query->whereIn('master_faskes.id_tipe_faskes', [1, 2, 3]);
+                        },  function ($query) use ($request) {
+                            $query->whereIn('master_faskes.id_tipe_faskes', [4, 5]);
+                        });
+                    })
                     ->when($request->has('verification_status'), function ($query) use ($request) {
                         $query->where('master_faskes.verification_status', '=', $request->input('verification_status'));
                     }, function ($query) use ($request) {

--- a/app/Http/Controllers/API/v1/MasterFaskesController.php
+++ b/app/Http/Controllers/API/v1/MasterFaskesController.php
@@ -21,7 +21,7 @@ class MasterFaskesController extends Controller
         $sort = $this->getValidOrderDirection($request->input('sort'));
         $isPaginated = $request->input('is_paginated', 1);
 
-        $data = MasterFaskes::with('masterFaskesType')
+        $data = MasterFaskes::with(['masterFaskesType', 'village'])
                 ->where(function ($query) use ($request) {
                     $query->when($request->has('nama_faskes'), function ($query) use ($request) {
                         $query->where('master_faskes.nama_faskes', 'LIKE', "%{$request->input('nama_faskes')}%");
@@ -47,7 +47,7 @@ class MasterFaskesController extends Controller
                 })
                 ->orderBy('nama_faskes', $sort);
 
-        $data = $isPaginated ? $data->paginate($limit) : $data->select('id', 'nama_faskes')->get();
+        $data = $isPaginated ? $data->paginate($limit) : $data->select('id', 'nama_faskes', 'id_tipe_faskes', 'kode_kel_kemendagri')->get();
 
         return response()->format(Response::HTTP_OK, 'success', $data);
     }

--- a/app/Http/Controllers/API/v1/MasterFaskesController.php
+++ b/app/Http/Controllers/API/v1/MasterFaskesController.php
@@ -6,6 +6,7 @@ use App\MasterFaskes;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\VaccineRequest\GetMasterFaskesRequest;
+use App\MasterFaskesType;
 use App\Traits\PaginateTrait;
 use App\Validation;
 use Illuminate\Http\Response;
@@ -31,9 +32,9 @@ class MasterFaskesController extends Controller
                     })
                     ->when($request->has('is_faskes'), function ($query) use ($request) {
                         $query->when($request->input('is_faskes'), function ($query) use ($request) {
-                            $query->whereIn('master_faskes.id_tipe_faskes', [1, 2, 3]);
+                            $query->whereIn('master_faskes.id_tipe_faskes', MasterFaskesType::HEALTH_FACILITY);
                         },  function ($query) use ($request) {
-                            $query->whereIn('master_faskes.id_tipe_faskes', [4, 5]);
+                            $query->whereIn('master_faskes.id_tipe_faskes', MasterFaskesType::NON_HEALTH_FACILITY);
                         });
                     })
                     ->when($request->has('verification_status'), function ($query) use ($request) {

--- a/app/Http/Requests/VaccineRequest/GetMasterFaskesRequest.php
+++ b/app/Http/Requests/VaccineRequest/GetMasterFaskesRequest.php
@@ -29,6 +29,7 @@ class GetMasterFaskesRequest extends FormRequest
             'limit' => 'nullable|numeric',
             'page' => 'nullable|numeric',
             'is_paginated' => 'boolean',
+            'is_faskes' => 'boolean',
             'id_tipe_faskes' => 'nullable|exists:master_faskes_types,id',
             'verification_status' => [new EnumRule(MasterFaskesVerificationStatusEnum::class)],
         ];

--- a/app/MasterFaskes.php
+++ b/app/MasterFaskes.php
@@ -35,6 +35,11 @@ class MasterFaskes extends Model
         return $this->hasOne('App\MasterFaskesType', 'id', 'id_tipe_faskes');
     }
 
+    public function village()
+    {
+        return $this->hasOne('App\Village', 'kemendagri_desa_kode', 'kode_kel_kemendagri');
+    }
+
     public function getVerificationStatusAttribute($value)
     {
         $status = $value === self::STATUS_NOT_VERIFIED ? 'Belum Terverifikasi' : ($value === self::STATUS_VERIFIED ? 'Terverifikasi' : '');

--- a/app/MasterFaskesType.php
+++ b/app/MasterFaskesType.php
@@ -9,6 +9,9 @@ class MasterFaskesType extends Model
     protected $table = 'master_faskes_types';
     protected $fillable = ['name', 'is_imported', 'non_public'];
 
+    const HEALTH_FACILITY = [1, 2, 3]; //1. Rumah Sakit, 2. Puskesmas, 3. Klinik
+    const NON_HEALTH_FACILITY = [4, 5]; //4. Masyarakat Umum, 5. Instansi Lainnya
+
     public function masterFaskes()
     {
         return $this->belongsToOne('App\MasterFaskes', 'id_tipe_faskes');


### PR DESCRIPTION
## Changes
- Bugfix `is_paginated` was wrong when examine the condition. It must opposite condition from before.
  - Example:
    if `is_paginated` == 1 (true), filter condition must be show data with pagination.

-  Filtering updates:
  - add new filter. `is_faskes`. Value must be boolean. not required. It filter data by faskes (Fasilitas Kesehatan) or non faskes. Faskes in database is include "rumah sakit" (1), "Puskesmas" (2) and "Klinik" (3). other than that is non faskes (4 (Masyarakat Umum) and 5 (Instansi Lainnya)
  - add eager load for village at Master Faskes model.

## Evidence
project: Pikobar Logistik
title:  Master Faskes Service - Bug `is_paginated` & Filtering Updates
participants: @rindibudiaramdhan