### PR TITLE
API Vaccine Request List - Filter By status `rejected`

### DIFF
--- a/app/Enums/VaccineRequestStatusEnum.php
+++ b/app/Enums/VaccineRequestStatusEnum.php
@@ -5,6 +5,7 @@ namespace App\Enums;
 use Spatie\Enum\Enum;
 
 /**
+ * @method static self rejected()
  * @method static self approval_rejected()
  * @method static self verification_rejected()
  * @method static self not_verified()

--- a/app/VaccineRequest.php
+++ b/app/VaccineRequest.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use App\Enums\VaccineRequestStatusEnum;
 use Illuminate\Database\Eloquent\Model;
 use JWTAuth;
 
@@ -83,7 +84,11 @@ class VaccineRequest extends Model
     public function scopeFilter($query, $request)
     {
         $query->when($request->input('status'), function ($query) use ($request) {
-            $query->where('status', $request->input('status'));
+            $query->when($request->input('status') == VaccineRequestStatusEnum::rejected(), function ($query) use ($request) {
+                $query->whereIn('status', [VaccineRequestStatusEnum::verification_rejected(), VaccineRequestStatusEnum::approval_rejected()]);
+            }, function ($query) use ($request) {
+                $query->where('status', $request->input('status'));
+            });
         })
         ->when($request->input('start_date') && $request->input('end_date'), function ($query) use ($request) {
             $start_date = $request->input('start_date') . ' 00:00:00';


### PR DESCRIPTION
# Changes
status rejected at vaccine request is divided by 2 type:
1. `verification_rejected`, rejected at verification phase
2. `approval_rejected`, rejected at approval phase

to put it simple for FrontEnd, I suggest to set `status` = `rejected`, so system will filter data by status in that 2 types of rejected

# Evidence
title: API Vaccine Request List - Filter By status `rejected`
project: Pikobar Logistik
participants: @rindibudiaramdhan @sandisunandar99 @ayocodingit 

cc: @jabardigitalservice/jds-backend 