### PR TITLE
hotfix recommendation_reason is not required

### DIFF
--- a/app/Http/Requests/VaccineRequest/StoreVaccineProductRequest.php
+++ b/app/Http/Requests/VaccineRequest/StoreVaccineProductRequest.php
@@ -39,7 +39,7 @@ class StoreVaccineProductRequest extends FormRequest
                 'required',
                 Rule::in([VaccineProductRequestStatusEnum::urgent(), VaccineProductRequestStatusEnum::other()])
             ],
-            'recommendation_reason' => 'required',
+            'recommendation_reason' => 'nullable',
             'recommendation_file' => 'required|mimes:jpeg,jpg,png,pdf|max:10240',
             'description' => 'nullable',
             'usage' => 'required',


### PR DESCRIPTION
for API Store/Create New Vaccine Product Request