### PR TITLE
[Hotfix] Error setParamStore()

### DIFF
--- a/app/LogisticRequest.php
+++ b/app/LogisticRequest.php
@@ -28,7 +28,7 @@ class LogisticRequest extends Model
         ];
     }
 
-    static function setParamStore(Request $request)
+    static function setParamStore($request)
     {
         $param = [
             'master_faskes_id' => 'required|numeric',


### PR DESCRIPTION
## Overview
Fix Log of Error:
`Argument 1 passed to App\LogisticRequest::setParamStore() must be an instance of Illuminate\Http\Request, instance of Illuminate\Http\JsonResponse given, called in /var/www/html/app/Http/Controllers/API/v1/LogisticRequestController.php on line 56`