### PR TITLE
Fix Error API Post Master Faskes

### DIFF
--- a/app/Http/Requests/MasterFaskes/StoreMasterFaskesRequest.php
+++ b/app/Http/Requests/MasterFaskes/StoreMasterFaskesRequest.php
@@ -28,11 +28,11 @@ class StoreMasterFaskesRequest extends FormRequest
         return [
             'nama_faskes' => 'required',
             'id_tipe_faskes' => 'required|numeric|exists:master_faskes_types,id',
-            'nomor_telepon' => 'required|numeric',
-            'kode_kab_kemendagri' => 'required|exists:districtcities,kemendagri_kabupaten_kode',
-            'kode_kec_kemendagri' => 'required|exists:subdistricts,kemendagri_kecamatan_kode',
-            'kode_kel_kemendagri' => 'required|exists:villages,kemendagri_desa_kode',
-            'alamat' => 'required',
+            'nomor_telepon' => 'numeric',
+            'kode_kab_kemendagri' => 'exists:districtcities,kemendagri_kabupaten_kode',
+            'kode_kec_kemendagri' => 'exists:subdistricts,kemendagri_kecamatan_kode',
+            'kode_kel_kemendagri' => 'exists:villages,kemendagri_desa_kode',
+            'alamat' => 'nullable',
             'permit_file' => 'mimes:jpeg,jpg,png|max:10240',
             'verification_status' => [new EnumRule(MasterFaskesVerificationStatusEnum::class)],
         ];

--- a/tests/Feature/MasterFaskesTest.php
+++ b/tests/Feature/MasterFaskesTest.php
@@ -102,11 +102,9 @@ class MasterFaskesTest extends TestCase
         $data = [
             'nama_faskes' => $faskesName,
             'id_tipe_faskes' => 5,
-            'nomor_telepon' => '+6281098765432',
-            'kode_kab_kemendagri' => '32.01',
-            'kode_kec_kemendagri' => '32.01.01',
-            'kode_kel_kemendagri' => '32.01.01.1001',
-            'alamat' => 'jl. ' . $this->faker->company . ' No. ' . rand()
+            'nama_atasan' => $this->faker->name,
+            'nomor_izin_sarana' => 'NOMOR/IZIN/SARANA/' . rand(),
+            'nomor_registrasi' => 'NOMOR/IZIN/REGISTRASI/' . rand(),
         ];
 
         $response = $this->actingAs($this->admin, 'api')->json('POST', '/api/v1/master-faskes', $data);


### PR DESCRIPTION
## Overview
- got report that error in this area
![telegram-cloud-photo-size-5-6059829633953673922-x](https://user-images.githubusercontent.com/19951241/168718412-7c2cfc2a-61fc-4c3e-ba30-bc138d4675f0.jpg)
- this is because from FE only send this payloads
```
{
  id_tipe_faskes: 2,
  nama_atasan: "123",
  nama_faskes: "123",
  nomor_izin_sarana: "123",
  nomor_registrasi: "123",
  permit_file: File { name: "71733-headset.png", lastModified: 1514711220000, size: 11110, … },
  point_latitude_longitude: "123"
}
```

so, to solving this, I remove `required` from each locking Store payload

## Evidence
title: Fix Error API Post Master Faskes
project: Pikobar Logistik
participants: @rindibudiaramdhan @firmanhxc @sandisunandar99 @indraprasetya154 @ayocodingit 