### PR TITLE
(Medical Logistic) fix product_id is null when status not_available

### DIFF
--- a/app/Http/Requests/LogisticRealizationItem/StoreRequest.php
+++ b/app/Http/Requests/LogisticRealizationItem/StoreRequest.php
@@ -31,7 +31,7 @@ use Illuminate\Validation\Rule;
             'agency_id' => 'required|numeric',
             'applicant_id' => 'required|numeric',
             'need_id' => 'required|numeric',
-            'product_id' => 'string',
+            'product_id' => 'nullable|string',
             'status' => ['required', Rule::in(LogisticRealizationItems::STATUS)],
             'store_type' => 'required|string',
             'product_name' => 'nullable',

--- a/app/Http/Requests/LogisticRealizationItem/StoreRequest.php
+++ b/app/Http/Requests/LogisticRealizationItem/StoreRequest.php
@@ -6,7 +6,7 @@ use App\LogisticRealizationItems;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-class StoreRequest extends FormRequest
+    class StoreRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -31,7 +31,7 @@ class StoreRequest extends FormRequest
             'agency_id' => 'required|numeric',
             'applicant_id' => 'required|numeric',
             'need_id' => 'required|numeric',
-            'product_id' => 'required|string',
+            'product_id' => 'string',
             'status' => ['required', Rule::in(LogisticRealizationItems::STATUS)],
             'store_type' => 'required|string',
             'product_name' => 'nullable',

--- a/app/Http/Requests/LogisticRealizationItem/StoreRequest.php
+++ b/app/Http/Requests/LogisticRealizationItem/StoreRequest.php
@@ -6,7 +6,7 @@ use App\LogisticRealizationItems;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-    class StoreRequest extends FormRequest
+class StoreRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.


### PR DESCRIPTION
## Overview
- Error when user set status not available
<img width="746" alt="image" src="https://user-images.githubusercontent.com/19951241/169181578-fc49222f-77e2-46c1-bc90-b872c3aa6380.png">
- this is because product_id null. null because not need picked when status not available

## Evidence
title: fix product_id is null when status not_available
project: Pikobar Logistik Alkes
participants: @rindibudiaramdhan @ayocodingit @imamdev93 