### PR TITLE
Medical Logistic - Error when update recommendation item

### DIFF
--- a/app/Http/Requests/LogisticRealizationItem/AddRequest.php
+++ b/app/Http/Requests/LogisticRealizationItem/AddRequest.php
@@ -38,13 +38,15 @@ class AddRequest extends FormRequest
 
         if (!in_array($this->status, [LogisticRealizationItems::STATUS_NOT_AVAILABLE, LogisticRealizationItems::STATUS_NOT_YET_FULFILLED])) {
             $params += [
-                'recommendation_quantity' => 'required_if:store_type,recommendation',
-                'recommendation_date' => 'required_if:store_type,recommendation|date',
-                'recommendation_unit' => 'required_if:store_type,recommendation|string',
-                'realization_quantity' => 'required_if:store_type,realization',
-                'realization_date' => 'required_if:store_type,realization|date',
-                'realization_unit' => 'required_if:store_type,realization|string',
-                'material_group' => 'exclude_if:store_type,realization|nullable',
+                'recommendation_quantity' => 'nullable',
+                'recommendation_date' => 'nullable|date',
+                'recommendation_unit' => 'nullable|string',
+                'recommendation_unit_id' => 'nullable|string',
+                'realization_quantity' => 'nullable',
+                'realization_date' => 'nullable|date',
+                'realization_unit' => 'nullable|string',
+                'realization_unit_id' => 'nullable|string',
+                'material_group' => 'nullable|nullable',
             ];
         }
         return $params;

--- a/tests/Feature/LogisticRealizationItemTest.php
+++ b/tests/Feature/LogisticRealizationItemTest.php
@@ -215,7 +215,35 @@ class LogisticRealizationItemTest extends TestCase
             ]);
     }
 
-    public function testEdit()
+    public function testEditRecommendation()
+    {
+        $param = $this->param;
+        $param['store_type'] = 'recommendation';
+        $param['recommendation_quantity'] = rand(1, 1000);
+        $param['recommendation_date'] = date('Y-m-d');
+        $param['recommendation_unit'] = 'PCS';
+
+        $this
+            ->actingAs($this->admin, 'api')
+            ->json('POST', '/api/v1/logistic-admin-realization', $param);
+
+        $realizationItem = LogisticRealizationItems::first();
+
+        $param = $this->param;
+        $param['store_type'] = 'recommendation';
+        $param['recommendation_quantity'] = rand(1, 1000);
+        $param['recommendation_date'] = date('Y-m-d');
+        $param['recommendation_unit'] = 'PCS';
+        $param['realization_quantity'] = null;
+        $param['realization_date'] =null;
+        $param['realization_unit'] = null;
+
+        $update = $this
+            ->actingAs($this->admin, 'api')->json('PUT', '/api/v1/logistic-admin-realization/' . $realizationItem->id, $param)
+            ->assertSuccessful();
+    }
+
+    public function testEditRealization()
     {
         $param = $this->param;
         $param['store_type'] = 'recommendation';


### PR DESCRIPTION
## Overview
- Error update recommendation item when realization_data is null & realization_unit is null

## Evidence
- title: Medical Logistic - Error when update recommendation item
- project: Pikobar Logistik
- participants: @rindibudiaramdhan @ayocodingit 