### PR TITLE
Implementation Queue Worker to Reduce Sending Email Process Time

### DIFF
--- a/app/Mail/LogisticEmailNotification.php
+++ b/app/Mail/LogisticEmailNotification.php
@@ -9,7 +9,7 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-class LogisticEmailNotification extends Mailable
+class LogisticEmailNotification extends Mailable implements ShouldQueue
 {
     use Queueable, SerializesModels;
 

--- a/app/Mail/TokenEmailNotification.php
+++ b/app/Mail/TokenEmailNotification.php
@@ -7,7 +7,7 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-class TokenEmailNotification extends Mailable
+class TokenEmailNotification extends Mailable implements ShouldQueue
 {
     use Queueable, SerializesModels;
 

--- a/app/Mail/Vaccine/ConfirmEmailNotification.php
+++ b/app/Mail/Vaccine/ConfirmEmailNotification.php
@@ -8,7 +8,7 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-class ConfirmEmailNotification extends Mailable
+class ConfirmEmailNotification extends Mailable implements ShouldQueue
 {
     use Queueable, SerializesModels;
 

--- a/app/Mail/Vaccine/VerifiedEmailNotification.php
+++ b/app/Mail/Vaccine/VerifiedEmailNotification.php
@@ -12,7 +12,7 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-class VerifiedEmailNotification extends Mailable
+class VerifiedEmailNotification extends Mailable implements ShouldQueue
 {
     use Queueable, SerializesModels;
 

--- a/database/migrations/2022_07_05_025539_create_jobs_table.php
+++ b/database/migrations/2022_07_05_025539_create_jobs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateJobsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('jobs');
+    }
+}


### PR DESCRIPTION
## Overview
- Implementation queue for send email that cost 3+ secs because of sending email process.
- Implementation queue database driver.
<img width="800" alt="image" src="https://user-images.githubusercontent.com/19951241/177248960-31cacaf5-f3cf-4271-b8fb-9b4f0b4f3e91.png">

## To Do After Merge
- `php artisan migrate`
- setup worker server

## Evidence
- title: Implementation Queue Worker to Reduce Sending Email Process Time
- project: Pikobar Logistik
- participants: @rindibudiaramdhan @sandisunandar99 @azophy 