### PR TITLE
API Reject Vaccine Request & API Integrate Vaccine Request new validating

### DIFF
--- a/app/Http/Controllers/API/v1/Vaccine/VaccineRequestController.php
+++ b/app/Http/Controllers/API/v1/Vaccine/VaccineRequestController.php
@@ -44,6 +44,16 @@ class VaccineRequestController extends Controller
         return $resource;
     }
 
+    public function archiveList($request)
+    {
+        $limit = $request->input('limit', 5);
+        $data = Archive::filter($request)
+            ->sort($request);
+
+        $data->select( 'id', 'delivery_plan_date', 'agency_name', 'is_letter_file_final', 'verification_status', 'note', 'status', 'status_rank');
+        return VaccineRequestArchiveResource::collection($data->paginate($limit));
+    }
+
     public function show($id, Request $request)
     {
         $data = VaccineRequest::with([

--- a/app/Models/Vaccine/VaccineRequest.php
+++ b/app/Models/Vaccine/VaccineRequest.php
@@ -127,7 +127,7 @@ class VaccineRequest extends Model
 
                 case VaccineRequestStatusEnum::verified_with_note():
                     $query
-                        ->where('status', '!=', VaccineRequestStatusEnum::not_verified())
+                        ->whereNotIn('status', [VaccineRequestStatusEnum::not_verified(), VaccineRequestStatusEnum::rejected()])
                         ->whereHas('vaccineRequestStatusNotes');
                     break;
 

--- a/app/VaccineWmsJabar.php
+++ b/app/VaccineWmsJabar.php
@@ -114,6 +114,11 @@ class VaccineWmsJabar extends WmsJabar
     {
         try {
             $config = self::setStoreRequest($vaccineRequest);
+            $items = $config['param']['data']['finalization_items'];
+            // Validate if $items is empty
+            if (!(count($items) > 0)) {
+                return response()->format(Response::HTTP_INTERNAL_SERVER_ERROR, 'Maaf, tidak ada barang yang dapat dilanjutkan ke WMS Poslog di permohonan ini. Mohon dicek kembali kuantitas di tiap barangnya.', $items);
+            }
 
             // Validate Stock per item to API SOH
             $result = self::isValidStock($items);

--- a/app/VaccineWmsJabar.php
+++ b/app/VaccineWmsJabar.php
@@ -115,26 +115,23 @@ class VaccineWmsJabar extends WmsJabar
         try {
             $config = self::setStoreRequest($vaccineRequest);
             $items = $config['param']['data']['finalization_items'];
-            // Validate if $items is empty
-            if (!(count($items) > 0)) {
-                return response()->format(Response::HTTP_INTERNAL_SERVER_ERROR, 'Maaf, tidak ada barang yang dapat dilanjutkan ke WMS Poslog di permohonan ini. Mohon dicek kembali kuantitas di tiap barangnya.', $items);
+
+            // Pre-Validating before Integrating to WMS Poslog
+            $isValidToIntegrate = self::isValidToIntegrate($items);
+            if (!$isValidToIntegrate['status'] == Response::HTTP_OK) {
+                return response()->format($isValidToIntegrate['status'], $isValidToIntegrate['message'], $isValidToIntegrate['data']);
             }
 
-            // Validate Stock per item to API SOH
-            $result = self::isValidStock($items);
-            if (!$result['is_valid']) {
-                return response()->format(Response::HTTP_INTERNAL_SERVER_ERROR, $result['message'], $result);
-            }
-
+            // Integrating to WMS Poslog
             $config['apiFunction'] = '/api_vaksin/index.php?route=pingme_v2';
             $config['url_type'] = 'vaccine';
             $res = self::callAPI($config, 'post');
 
             $data = json_decode($res->getBody(), true);
 
+            // Handling Validation by WMS Poslog
             if (!isset($data['result'])) {
-                return response()->format($data['stt'], 'Failed at WMS Poslog: ' . $data['msg'],
-                [
+                return response()->format($data['stt'], 'Failed at WMS Poslog: ' . $data['msg'], [
                     'poslog_error' => $data,
                     'config_data' => $config
                 ]);
@@ -147,17 +144,40 @@ class VaccineWmsJabar extends WmsJabar
         }
     }
 
-    static function isValidStock($items)
+    static function isValidToIntegrate($items)
     {
         $result = [
-            'is_valid' => true,
-            'items' => $items,
-            'message' => '',
+            'status' => Response::HTTP_OK,
+            'message' => 'valid',
+            'data' => [],
         ];
 
-        $data = [];
-        $message = '';
+        // Validate if $items is empty
+        if (!(count($items) > 0)) {
+            $result['status'] = Response::HTTP_INTERNAL_SERVER_ERROR;
+            $result['message'] = 'Maaf, tidak ada barang yang dapat dilanjutkan ke WMS Poslog di permohonan ini. Mohon dicek kembali kuantitas di tiap barangnya.';
+            $result['data'] = $items;
+        }
+
+        // Validate Stock per item to API SOH
+        $result = self::isValidStock($items);
+        if (!$result['is_valid']) {
+            $result['status'] = Response::HTTP_INTERNAL_SERVER_ERROR;
+            $result['message'] = $result['message'];
+            $result['data'] = $result['items'];
+        }
+
+        return $result;
+    }
+
+    static function isValidStock($items)
+    {
+        $result['is_valid'] = true;
+        $result['items'] = $items;
+        $result['message'] = '';
+
         foreach ($items as $key => $item) {
+            // Get Current Stock from WMS Poslog
             $config['apiFunction'] = '/api_vaksin/index.php?route=soh_fmaterial';
             $config['url_type'] = 'vaccine';
             $config['param']['material_id'] = $item['final_product_id'];
@@ -165,29 +185,32 @@ class VaccineWmsJabar extends WmsJabar
             $res = self::callAPI($config, 'post');
 
             $response = json_decode($res->getBody(), true);
-            $data[] = $response;
 
             // If Status (stt) Fail/Error.
             if ($response['stt'] == 0) {
-                $message .= '['. $item['final_product_id'] . '] ' . $item['final_product_name'] . ' ' . $response['msg'] . '. ';
+                $result['message'] .= '['. $item['final_product_id'] . '] ' . $item['final_product_name'] . ' ' . $response['msg'] . '. ';
                 $result['is_valid'] = false;
                 continue;
             }
 
-            $items[$key]['final_soh_location'] = $response['msg'][0]['soh_location'];
-            $items[$key]['final_soh_location_name'] = $response['msg'][0]['soh_location_name'];
+            $result['items'][$key]['final_soh_location'] = $response['msg'][0]['soh_location'];
+            $result['items'][$key]['final_soh_location_name'] = $response['msg'][0]['soh_location_name'];
 
-            // Validating Stock if stock below from request
-            $stock = $response['msg'][0]['stock_ok'] - $response['msg'][0]['stock_nok'] - $response['msg'][0]['booked_stock'];
-            if ($stock < $item['final_quantity']) {
-                $message .= '['. $item['final_product_id'] . '] ' . $item['final_product_name'] . ' stok kurang/tidak ada. (' . $stock . '<' . $item['final_quantity'] . ')';
-                $result['is_valid'] = false;
-                continue;
-            }
+            $result = self::setValidatingStockResult($result, $response, $item);
         }
 
-        $result['message'] = $message;
-        $result['items'] = $items;
+        return $result;
+    }
+
+    static function setValidatingStockResult($result, $response, $item)
+    {
+        // Validating Stock if stock below from request
+        $stock = $response['msg'][0]['stock_ok'] - $response['msg'][0]['stock_nok'] - $response['msg'][0]['booked_stock'];
+        if ($stock < $item['final_quantity']) {
+            $result['message'] .= '['. $item['final_product_id'] . '] ' . $item['final_product_name'] . ' stok kurang/tidak ada. (' . $stock . '<' . $item['final_quantity'] . ')';
+            $result['is_valid'] = false;
+        }
+
         return $result;
     }
 }

--- a/app/VaccineWmsJabar.php
+++ b/app/VaccineWmsJabar.php
@@ -75,6 +75,7 @@ class VaccineWmsJabar extends WmsJabar
                 $vaccineProductRequests[] = [
                     'id' => $product->id,
                     'final_product_id' => $product->finalized_product_id,
+                    'final_product_name' => $product->finalized_product_name,
                     'final_quantity' => $product->finalized_quantity,
                     'final_soh_location' => $soh_location->soh_location ?? "",
                 ];
@@ -113,6 +114,13 @@ class VaccineWmsJabar extends WmsJabar
     {
         try {
             $config = self::setStoreRequest($vaccineRequest);
+
+            // Validate Stock per item to API SOH
+            $result = self::isValidStock($items);
+            if (!$result['is_valid']) {
+                return response()->format(Response::HTTP_INTERNAL_SERVER_ERROR, $result['message'], $result);
+            }
+
             $config['apiFunction'] = '/api_vaksin/index.php?route=pingme_v2';
             $config['url_type'] = 'vaccine';
             $res = self::callAPI($config, 'post');
@@ -132,5 +140,49 @@ class VaccineWmsJabar extends WmsJabar
         } catch (\Exception $exception) {
             return response()->format(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getMessage(), $exception->getTrace());
         }
+    }
+
+    static function isValidStock($items)
+    {
+        $result = [
+            'is_valid' => true,
+            'items' => $items,
+            'message' => '',
+        ];
+
+        $data = [];
+        $message = '';
+        foreach ($items as $key => $item) {
+            $config['apiFunction'] = '/api_vaksin/index.php?route=soh_fmaterial';
+            $config['url_type'] = 'vaccine';
+            $config['param']['material_id'] = $item['final_product_id'];
+            $config['method'] = $item['final_product_id'];
+            $res = self::callAPI($config, 'post');
+
+            $response = json_decode($res->getBody(), true);
+            $data[] = $response;
+
+            // If Status (stt) Fail/Error.
+            if ($response['stt'] == 0) {
+                $message .= '['. $item['final_product_id'] . '] ' . $item['final_product_name'] . ' ' . $response['msg'] . '. ';
+                $result['is_valid'] = false;
+                continue;
+            }
+
+            $items[$key]['final_soh_location'] = $response['msg'][0]['soh_location'];
+            $items[$key]['final_soh_location_name'] = $response['msg'][0]['soh_location_name'];
+
+            // Validating Stock if stock below from request
+            $stock = $response['msg'][0]['stock_ok'] - $response['msg'][0]['stock_nok'] - $response['msg'][0]['booked_stock'];
+            if ($stock < $item['final_quantity']) {
+                $message .= '['. $item['final_product_id'] . '] ' . $item['final_product_name'] . ' stok kurang/tidak ada. (' . $stock . '<' . $item['final_quantity'] . ')';
+                $result['is_valid'] = false;
+                continue;
+            }
+        }
+
+        $result['message'] = $message;
+        $result['items'] = $items;
+        return $result;
     }
 }

--- a/database/migrations/2022_07_18_020839_create_failed_jobs_table.php
+++ b/database/migrations/2022_07_18_020839_create_failed_jobs_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFailedJobsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('failed_jobs');
+    }
+}

--- a/resources/views/email/vaccine/rejected-email-notification.blade.php
+++ b/resources/views/email/vaccine/rejected-email-notification.blade.php
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="X-UA-Compatible" content="ie=edge">
+        <title>E-Mail PIKOBAR</title>
+        <style>
+            #customers {
+                font-family: Arial, Helvetica, sans-serif;
+                border-collapse: collapse;
+                width: 100%;
+            }
+            #customers td, #customers th {
+                border: 1px solid #ddd;
+                padding: 8px;
+            }
+            #customers tr:nth-child(even){background-color: #f2f2f2;}
+            #customers tr:hover {background-color: #ddd;}
+            #customers th {
+                padding-top: 12px;
+                padding-bottom: 12px;
+                text-align: left;
+                background-color: #04AA6D;
+                color: white;
+            }
+            .card-box {
+                float: left;
+                border: 1px border rgb(56, 56, 56);
+                background-color: rgb(234, 234, 234);
+                border-radius: 15px;
+                padding: 15px;
+                width: 100%;
+            }
+            .card-box-col-2 {
+                float: left;
+                border: 1px border rgb(56, 56, 56);
+                background-color: rgb(234, 234, 234);
+                border-radius: 15px;
+                padding: 15px;
+                width: 40%;
+                margin: 5px;
+            }
+            /* Clear floats after the columns */
+            .row:after {
+                content: "";
+                display: table;
+                clear: both;
+            }
+        </style>
+    </head>
+    <body>
+
+        <div>
+            <div>Kepada Yth. {{ $data->applicant_fullname }}</div>
+        </div>
+        <div>
+            <div>{{ $data->agency_name }}</div>
+        </div>
+        <div>
+            <br>
+            Terimakasih telah melakukan permohonan pada Aplikasi Permohonan Logistik Pikobar Vaksin. Melalui email ini, kami mengabarkan hasil verifikasi permohonan Logistik Vaksin anda sebagai berikut:
+            <br>
+            <br>
+            <div class="row">
+                <div class="card-box-col-2">
+                    ID Permohonan
+                    <br>
+                    <b>{{ $data->id }}</b>
+                </div>
+                <div class="card-box-col-2">
+                    Status Permohonan
+                    <br>
+                    <b style="color: red">Ditolak</b>
+                </div>
+            </div>
+            <br>
+            <div class="row card-box">
+                Alasan Penolakan<br>
+                {!! $data->note !!}
+                <br>
+                @foreach ($notes as $note)
+                {!! $note !!}<br>
+                @endforeach
+            </div>
+            <div style="margin-top: 20px;">
+                Mohon Maaf atas ketidaknyamanan ini. Mohon ajukan permohonan kembali jika masih membutuhkan logistik untuk instansi Anda.
+            </div>
+            <br>
+        </div>
+        <br>
+        <div>
+            <div><b>Salam hormat kami,</b></div>
+            <div>{{ $from }}</div>
+            <div>Whatsapp Admin Logistik Vaksin Pikobar: {{ $hotLine }}</div>
+            <div>Email: {{ $email }}</div>
+        </div>
+
+    </body>
+</html>


### PR DESCRIPTION
## Overview
### API Reject Vaccine Request
- vaccine request can reject now.
- should send to user email when vaccine request is rejected
### API Integrate Vaccine Request new validating
- request should have item(s) to integrate with WMS Poslog
- requested items should valid real stock item

## Migrate Alert
- Need to execute `php artisan migrate` after deployed.

## Evidence
- title: API Reject Vaccine Request & API Integrate Vaccine Request new validating
- project: Pikobar Logistik
- participants: @rindibudiaramdhan @sandisunandar99 @ayocodingit 